### PR TITLE
Add comparison test

### DIFF
--- a/fast_matched_filter/__init__.py
+++ b/fast_matched_filter/__init__.py
@@ -8,7 +8,8 @@ init file for fast_matched_filter library
     (https://www.gnu.org/licenses/gpl-3.0.en.html)
 """
 
-from .fast_matched_filter import matched_filter, test_matched_filter
+from .fast_matched_filter import (
+    matched_filter, test_matched_filter, CPU_LOADED, GPU_LOADED)
 
 del fast_matched_filter
 

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -15,6 +15,8 @@ import os
 
 
 path = os.path.join(os.path.dirname(__file__), 'lib')
+CPU_LOADED = False
+GPU_LOADED = False
 
 try:
     _libCPU = ct.cdll.LoadLibrary(os.path.join(path, 'matched_filter_CPU.so'))
@@ -33,11 +35,11 @@ try:
         ct.c_size_t,               # n_components
         ct.c_size_t,               # n_corr
         ct.POINTER(ct.c_float)]    # cc_sums
-    cpu_loaded = True
+    CPU_LOADED = True
 except OSError:
     print("Matched-filter CPU is not compiled! Should be here: {}".
           format(os.path.join(path, 'matched_filter_CPU.so')))
-    cpu_loaded = False
+    CPU_LOADED = False
 
 try:
     _libGPU = ct.cdll.LoadLibrary(os.path.join(path, 'matched_filter_GPU.so'))
@@ -55,11 +57,11 @@ try:
         ct.c_size_t,               # n_components
         ct.c_size_t,               # n_corr
         ct.POINTER(ct.c_float)]    # cc_sums
-    gpu_loaded = True
+    GPU_LOADED = True
 except OSError:
     print("Matched-filter GPU is not compiled! Should be here: {}".
           format(os.path.join(path, 'matched_filter_GPU.so')))
-    gpu_loaded = False
+    GPU_LOADED = False
 
 
 def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
@@ -81,9 +83,9 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
     2D numpy array (np.float32) [templates x time (at step defined interval)]
     """
 
-    if arch.lower() == 'cpu' and cpu_loaded is False:
+    if arch.lower() == 'cpu' and CPU_LOADED is False:
         loaded = False
-    elif arch.lower() == 'gpu' and gpu_loaded is False:
+    elif arch.lower() == 'gpu' and GPU_LOADED is False:
         loaded = False
     else:
         loaded = True


### PR DESCRIPTION
This PR adds an additional test to compare the results of the CPU and GPU implementations.  Currently it tests that they are accurate to within 0.0001.  Currently this fails.

This test will be skipped if either the CPU or GPU routines are not loaded (I changed `cpu_loaded` and `gpu_loaded` to upper-case, because this is often the case for module-level variables, and I made them visible by adding them to the `__init__.py` file).

This PR should be merged into `eric` before #9 is merged.