### PR TITLE
Force integer slicing when catching zeros

### DIFF
--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -184,9 +184,11 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
                 n_corr,
                 cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)))
     cc_sums = cc_sums.reshape((n_templates, n_corr))
-    zeros = np.sum(cc_sums[0,:n_corr-moveouts.max()/step] == 0.)
+    zeros = np.sum(cc_sums[0, : int(n_corr - moveouts.max() / step)] == 0.)
     if zeros > 10:
-        print("{} correlation computations were skipped. Can be caused by zeros in data, or too low amplitudes (try to increase the gain).".format(zeros))
+        print("{} correlation computations were skipped. Can be caused by"
+              " zeros in data, or too low amplitudes (try to increase the "
+              "gain).".format(zeros))
     return cc_sums
 
 


### PR DESCRIPTION
Hullo chaps, I was just playing around with this for comparison to obspy correlations (working on the PR [here](https://github.com/obspy/obspy/pull/2042)) and found that in Python 3 counting the number of zeros raised an error because slicing was done using a float rather than an int.  This PR forces the slice to be an integer, not sure if you want to round it before making it an int?

The code that raises the error is:
```python
import numpy as np
from fast_matched_filter import matched_filter
from obspy import read

data = read()[0].data
template = data[400:600]
data = data[380:620]
result = matched_filter(
    templates=template.reshape(1, 1, 1, len(template)),
    moveouts=np.array(0).reshape(1, 1, 1),
    weights=np.array(1).reshape(1, 1, 1),
    data=data.reshape(1, 1, len(data)),
    step=1, arch='cpu')[0]
```

Full traceback is:
```python
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-4-f8331551e803> in <module>()
      4             weights=np.array(1).reshape(1, 1, 1),
      5             data=data.reshape(1, 1, len(data)),
----> 6             step=1, arch='cpu')[0]
      7 

/home/sw/anaconda3/envs/conda_35/lib/python3.5/site-packages/fast_matched_filter/fast_matched_filter.py in matched_filter(templates, moveouts, weights, data, step, arch)
    185                 cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)))
    186     cc_sums = cc_sums.reshape((n_templates, n_corr))
--> 187     zeros = np.sum(cc_sums[0,:n_corr-moveouts.max()/step] == 0.)
    188     if zeros > 10:
    189         print("{} correlation computations were skipped. Can be caused by zeros in data, or too low amplitudes (try to increase the gain).".format(zeros))

TypeError: slice indices must be integers or None or have an __index__ method
```

This raises another interesting thing, I'm unsure why there are zeros at the end of the result?