### PR TITLE
Csum neumaier

### DIFF
--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -110,7 +110,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
                     templates[t, s, c, :n_samples_template] ** 2)
 
     templates = np.float32(templates.flatten())
-    sum_square_templates = np.float32(sum_square_templates.flatten())
+    sum_square_templates = sum_square_templates.flatten()
 
     # check shapes
     expected_size = n_templates * n_stations * n_components
@@ -126,7 +126,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
     # Note: shouldn't need to enforce int here because they were np.int32 before
 
     data = np.float32(data.flatten())
-    cc_sums = np.zeros(int(n_templates) * int(n_corr), dtype=np.float32)
+    cc_sums = np.zeros(n_templates * n_corr, dtype=np.float32)
 
     if arch == 'cpu':
         _libCPU.matched_filter(

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -12,7 +12,6 @@ import numpy as np
 import ctypes as ct
 import datetime as dt
 import os
-from IPython.core.debugger import Tracer; debug_here = Tracer()
 
 path = os.path.join(os.path.dirname(__file__), 'lib')
 CPU_LOADED = False

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -115,10 +115,10 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
 
     # check shapes
     expected_size = n_templates * n_stations * n_components
-    if expected_size/moveouts.size == n_components:
+    if expected_size / moveouts.size == n_components:
         # moveouts are specified per station
         moveouts = np.repeat(moveouts, n_components).reshape(n_templates, n_stations, n_components)
-    if expected_size/weights.size == n_components:
+    if expected_size / weights.size == n_components:
         # weights are specified per station
         weights = np.repeat(weights, n_components).reshape(n_templates, n_stations, n_components)
     moveouts = np.int32(moveouts.flatten())
@@ -161,7 +161,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
                 n_corr,
                 cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)))
     cc_sums = cc_sums.reshape((n_templates, n_corr))
-    zeros = np.sum(cc_sums[0, : int(n_corr - moveouts.max() / step)] == 0.)
+    zeros = np.sum(cc_sums[0, :int(n_corr - moveouts.max() / step)] == 0.)
     if zeros > 10:
         print("{} correlation computations were skipped. Can be caused by"
               " zeros in data, or too low amplitudes (try to increase the "
@@ -177,6 +177,9 @@ def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
     """
 
     template_times = np.random.random_sample(n_templates) * (data_duration / 2)
+    # if step is not 1, not very likely that random times will be found
+    if step != 1:
+        template_times = np.round(template_times / (step / sampling_rate)) * (step / sampling_rate)
     # determines how many templates there are
 
     min_moveout = 0

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -31,8 +31,9 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
     float *csum_square_data = NULL;
 
     // compute cumulative sum of squares of data
-    csum_square_data = malloc(n_samples_data * n_stations * n_components * sizeof(float));
-    csum_square_neumaier(data, n_samples_template, n_samples_data, n_stations, n_components, csum_square_data);
+    csum_square_data = malloc((n_samples_data * n_stations * n_components + 1) * sizeof(float));
+    csum_square_data[0] = 0.0;
+    cumsum_square_data(data, n_samples_data, weights, n_stations, n_components, csum_square_data + 1);
 
     // run matched filter template by template
     for (t = 0; t < n_templates; t++) {
@@ -63,7 +64,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
                                                         sum_square_templates_t,
                                                         moveouts_t,
                                                         data + i,
-                                                        csum_square_data + i,
+                                                        csum_square_data + i + 1,
                                                         weights_t,
                                                         n_samples_template,
                                                         n_samples_data,
@@ -119,7 +120,7 @@ float corrc(float *templates, float sum_square_template,
     for (i = 0; i < n_samples_template; i++){
         numerator += templates[i] * data[i];
     }
-    denominator = sum_square_template * csum_square_data[0];
+    denominator = sum_square_template * (csum_square_data[n_samples_template] - csum_square_data[-1]);
 
     if (denominator > STABILITY_THRESHOLD) cc = numerator / sqrt(denominator);
 
@@ -127,64 +128,47 @@ float corrc(float *templates, float sum_square_template,
 }
 
 //-------------------------------------------------------------------------
-void csum(double *data_sq, int n_samples_template, int n_samples_data,
-          int n_stations, int n_components,
-          double *csum_square_data) {
+void cumsum_square_data(float *data, int n_samples_data, float *weights,
+                        int n_stations, int n_components,
+                        float *csum_square_data) {
+    int s, c;
+    int station_offset, component_offset, d;
 
-    int ch, i, n;
-    for (ch = 0; ch < (n_stations*n_components); ch++){
-        double *csum_ch = NULL, *data_sq_ch = NULL;
-        csum_ch = csum_square_data + ch * n_samples_data;
-        data_sq_ch = data_sq + ch * n_samples_data;
+    for (s = 0; s < n_stations; s++) {
+        station_offset = s * n_components;
 
-        // sliding cumulative sum
-#pragma omp parallel for private(ch, i, n) shared(data_sq_ch, csum_ch)
-        for (n = 0; n < n_samples_data-n_samples_template; n++){
-            for (i = 0; i < n_samples_template; i++) csum_ch[n] += data_sq_ch[n+i];
+        for (c = 0; c < n_components; c++) {
+            component_offset = station_offset + c;
+            if (weights[component_offset] == 0) continue;
+            d = component_offset * n_samples_data;
+
+            neumaier_cumsum_squared(data + d, n_samples_data,
+                                    csum_square_data + d);
         }
     }
 }
 
 //-------------------------------------------------------------------------
-void csum_square_neumaier(float *data, int n_samples_template, int n_samples_data,
-          int n_stations, int n_components,
-          float *csum_square_data) {
+void neumaier_cumsum_squared(float *array, int length, float *cumsum) {
+    int i;
+    float running_sum, square, temporary;
+    float correction = 0.0;
 
-    int ch, i, channel_offset;
-    float running_csum, temp_csum, correction;
-    float data_squared, data_squared_before, data_squared_after, data_squared_difference;
+    running_sum = array[0] * array[0];
+    cumsum[0] = running_sum;
+    for (i = 1; i < length; i++) {
+        square = array[i] * array[i];
+        temporary = running_sum + square;
 
-    for (ch = 0; ch < (n_stations * n_components); ch++) {
-        channel_offset = ch * n_samples_data;
-
-        // start running csum
-        running_csum = data[channel_offset] * data[channel_offset];
-        correction = 0.0;
-        for (i = 1; i < n_samples_template; i++) {
-            data_squared = data[channel_offset + i] * data[channel_offset + i];
-            temp_csum = running_csum + data_squared;
-            
-            if (fabsf(running_csum) >= fabsf(data_squared)) correction += (running_csum - temp_csum) + data_squared;
-            else correction += (data_squared - temp_csum) + running_csum;
-
-            running_csum = temp_csum;
+        if (fabsf(running_sum) >= fabsf(square)) {
+            correction += (running_sum - temporary) + square;
         }
-        csum_square_data[channel_offset] = running_csum + correction;
-
-        // do everything else
-        for (i = 0; i < n_samples_data - n_samples_template - 1; i++) {
-            running_csum = csum_square_data[channel_offset + i];
-
-            data_squared_before = data[channel_offset + i] * data[channel_offset + i];
-            data_squared_after = data[channel_offset + i + n_samples_template] * data[channel_offset + i + n_samples_template];
-            data_squared_difference = data_squared_after - data_squared_before;
-
-            temp_csum = running_csum + data_squared_difference;
-            if (fabsf(running_csum) >= fabsf(data_squared_difference)) correction = (running_csum - temp_csum) + data_squared_difference;
-            else correction = (data_squared_difference - temp_csum) + running_csum;
-
-            csum_square_data[channel_offset + i + 1] = temp_csum + correction;
+        else {
+            correction += (square - temporary) + running_sum;
         }
+
+        running_sum = temporary;
+        cumsum[i] = temporary + correction;
     }
 }
 

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -131,20 +131,15 @@ float corrc(float *templates, float sum_square_template,
 void cumsum_square_data(float *data, int n_samples_data, float *weights,
                         int n_stations, int n_components,
                         double *csum_square_data) {
-    int s, c;
-    int station_offset, component_offset, d;
+    int ch, d;
 
-    for (s = 0; s < n_stations; s++) {
-        station_offset = s * n_components;
+    // loop over channels
+#pragma omp parallel for private(ch, d)
+    for (ch = 0; ch < n_stations * n_components; ch++) {
+        d = ch * n_samples_data;
 
-        for (c = 0; c < n_components; c++) {
-            component_offset = station_offset + c;
-            if (weights[component_offset] == 0) continue;
-            d = component_offset * n_samples_data;
-
-            neumaier_cumsum_squared(data + d, n_samples_data,
-                                    csum_square_data + d);
-        }
+        neumaier_cumsum_squared(data + d, n_samples_data,
+                                csum_square_data + d);
     }
 }
 

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -28,10 +28,10 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
     int network_offset, station_offset, cc_sum_offset;
     int *moveouts_t = NULL;
     float *templates_t = NULL, *sum_square_templates_t = NULL, *weights_t = NULL;
-    float *csum_square_data = NULL;
+    double *csum_square_data = NULL;
 
     // compute cumulative sum of squares of data
-    csum_square_data = malloc((n_samples_data * n_stations * n_components + 1) * sizeof(float));
+    csum_square_data = malloc((n_samples_data * n_stations * n_components + 1) * sizeof(double));
     csum_square_data[0] = 0.0;
     cumsum_square_data(data, n_samples_data, weights, n_stations, n_components, csum_square_data + 1);
 
@@ -78,7 +78,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
  
 //-------------------------------------------------------------------------
 float network_corr(float *templates, float *sum_square_template, int *moveouts,
-                   float *data, float *csum_square_data, float *weights,
+                   float *data, double *csum_square_data, float *weights,
                    int n_samples_template, int n_samples_data, int n_stations, int n_components) {
 
     int s, c, d, dd, t;
@@ -111,7 +111,7 @@ float network_corr(float *templates, float *sum_square_template, int *moveouts,
  
 //-------------------------------------------------------------------------
 float corrc(float *templates, float sum_square_template,
-            float *data, float *csum_square_data,
+            float *data, double *csum_square_data,
             int n_samples_template) {
 
     int i;
@@ -120,7 +120,7 @@ float corrc(float *templates, float sum_square_template,
     for (i = 0; i < n_samples_template; i++){
         numerator += templates[i] * data[i];
     }
-    denominator = sum_square_template * (csum_square_data[n_samples_template] - csum_square_data[-1]);
+    denominator = sum_square_template * (float)(csum_square_data[n_samples_template] - csum_square_data[-1]);
 
     if (denominator > STABILITY_THRESHOLD) cc = numerator / sqrt(denominator);
 
@@ -130,7 +130,7 @@ float corrc(float *templates, float sum_square_template,
 //-------------------------------------------------------------------------
 void cumsum_square_data(float *data, int n_samples_data, float *weights,
                         int n_stations, int n_components,
-                        float *csum_square_data) {
+                        double *csum_square_data) {
     int s, c;
     int station_offset, component_offset, d;
 
@@ -149,15 +149,15 @@ void cumsum_square_data(float *data, int n_samples_data, float *weights,
 }
 
 //-------------------------------------------------------------------------
-void neumaier_cumsum_squared(float *array, int length, float *cumsum) {
+void neumaier_cumsum_squared(float *array, int length, double *cumsum) {
     int i;
-    float running_sum, square, temporary;
-    float correction = 0.0;
+    double running_sum, square, temporary;
+    double correction = 0.0;
 
-    running_sum = array[0] * array[0];
+    running_sum = (double)array[0] * (double)array[0];
     cumsum[0] = running_sum;
     for (i = 1; i < length; i++) {
-        square = array[i] * array[i];
+        square = (double)array[i] * (double)array[i];
         temporary = running_sum + square;
 
         if (fabsf(running_sum) >= fabsf(square)) {

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -1,5 +1,5 @@
 void matched_filter(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
-float network_corr(float*, float*, int*, float*, float*, float*, int, int, int, int);
-float corrc(float*, float, float*, float*, int);
-void cumsum_square_data(float*, int, float*, int, int, float*);
-void neumaier_cumsum_squared(float*, int, float*);
+float network_corr(float*, float*, int*, float*, double*, float*, int, int, int, int);
+float corrc(float*, float, float*, double*, int);
+void cumsum_square_data(float*, int, float*, int, int, double*);
+void neumaier_cumsum_squared(float*, int, double*);

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -1,5 +1,5 @@
 void matched_filter(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
 float network_corr(float*, float*, int*, float*, float*, float*, int, int, int, int);
 float corrc(float*, float, float*, float*, int);
-void csum(double*, int, int, int, int, double*);
-void csum_square_neumaier(float*, int, int, int, int, float*);
+void cumsum_square_data(float*, int, float*, int, int, float*);
+void neumaier_cumsum_squared(float*, int, float*);

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -1,4 +1,5 @@
-void matched_filter(float*, float*, int*, float*, float*, float*, int, int, int, int, int, int, int, float*);
+void matched_filter(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
 float network_corr(float*, float*, int*, float*, float*, float*, int, int, int, int);
 float corrc(float*, float, float*, float*, int);
 void csum(double*, int, int, int, int, double*);
+void csum_square_neumaier(float*, int, int, int, int, float*);

--- a/fast_matched_filter/src/matched_filter_mex.c
+++ b/fast_matched_filter/src/matched_filter_mex.c
@@ -27,7 +27,7 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
     
     /* check for good number of inputs/outputs */
     if (nInputs != 12)
-        mexErrMsgIdAndTxt("Matlab:matched_filter.c", "Thirteen inputs required: \
+        mexErrMsgIdAndTxt("Matlab:matched_filter.c", "Twelve inputs required: \
                  templates (float*), \
                  sum_square_templates (float*), \
                  moveouts (int*), \
@@ -61,25 +61,6 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
     n_components = (int)mxGetScalar(ptrInputs[10]);
     n_corr = (int)mxGetScalar(ptrInputs[11]);
 
-
-    /* precompute cumulative sum of squares for data */
-    square_data = (double*)mxMalloc(n_samples_data * n_stations * n_components * sizeof(double));
-    csum_square_data = (double*)mxMalloc(n_samples_data * n_stations * n_components * sizeof(double));
-    csum_square_data_f = (float*)mxMalloc(n_samples_data * n_stations * n_components * sizeof(float));
-    
-    for (s = 0; s < n_stations; s++) {
-        for (c = 0; c < n_components; c++) {
-            data_offset = n_samples_data * (s * n_components + c);
-            
-            for (i = 0; i < n_samples_data; i++) square_data[data_offset + i] = (double)(data[data_offset + i] * data[data_offset + i]);
-            csum(square_data, n_samples_template, n_samples_data, n_stations, n_components, csum_square_data);
-            for (i = 0; i < n_samples_data; i++) csum_square_data_f[data_offset + i] = (float)csum_square_data[data_offset + i];
-        }
-    }
-    
-    mxFree(square_data);
-    mxFree(csum_square_data);
-   
     /* prepare outputs */
     const mwSize n_samples_out = n_corr * n_templates;
     ptrOutputs[0] = mxCreateNumericArray(1, &(n_samples_out), mxSINGLE_CLASS, mxREAL);
@@ -90,7 +71,6 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
                    sum_square_templates,
                    moveouts,
                    data,
-                   csum_square_data_f,
                    weights,
                    step,
                    n_samples_template,

--- a/fast_matched_filter/src/matched_filter_mex.c
+++ b/fast_matched_filter/src/matched_filter_mex.c
@@ -78,9 +78,5 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
                    n_components,
                    n_corr,
                    cc_sum); // output variable
-
-    mxFree(csum_square_data_f);
-    
-    //mxSetData(ptrOutputs[0], cc_sum);
 }
 

--- a/fast_matched_filter/src/matched_filter_mex.c
+++ b/fast_matched_filter/src/matched_filter_mex.c
@@ -17,7 +17,6 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
     int *moveouts = NULL, max_moveout = 0; // template moveout
     float *data = NULL; // data input
     double *square_data, *csum_square_data = NULL;
-    float *csum_square_data_f = NULL;
     float *weights = NULL; // weights for each CC
     int n_samples_template, n_samples_data, step;
     int n_templates, n_stations, n_components, n_corr; // size input
@@ -51,7 +50,6 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
     sum_square_templates = (float*)mxGetData(ptrInputs[1]);
     moveouts = (int*)mxGetData(ptrInputs[2]);
     data = (float*)mxGetData(ptrInputs[3]);
-    //csum_square_data = (float*)mxGetData(ptrInputs[4]);
     weights = (float*)mxGetData(ptrInputs[4]);
     step = (int)mxGetScalar(ptrInputs[5]);
     n_samples_template = (int)mxGetScalar(ptrInputs[6]);


### PR DESCRIPTION
Hello,

I've implemented a Neumaier sum to do the cumulative sum (https://en.wikipedia.org/wiki/Kahan_summation_algorithm). That way the normalization of the data in the correlation coefficient function only needs to do a subtraction to get the sum of the squares of the data.

I've also fixed an outstanding problem with the CPU version: the cumulative sum of squares was being calculated out of the matched_filter call. Now everything happens at once. This means there's no difference between the Matlab and python calls now.

There seems to be a strange bug with the python version when you use a step that's more than 1... I'm not sure yet where that is coming from; let me know if you have any ideas.

Otherwise, let me know if you can break it!

NB: Of course this only affects the CPU version of FMF.

**Edited to add the link.**