### PR TITLE
Fix the cumulative sum (and add a warning message in the test function)

### DIFF
--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -174,11 +174,6 @@ def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
     """
     output: templates, moveouts, data, step, cc_sum
     """
-    if float(int(sampling_rate)) != float(sampling_rate):
-        print('The sampling rate should be an integer !\nCorrect that before running the test function.')
-        return
-    else:
-        sampling_rate = int(sampling_rate)
 
     template_times = np.random.random_sample(n_templates) * (data_duration / 2)
     # if step is not 1, not very likely that random times will be found
@@ -197,6 +192,13 @@ def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
 
     # generate data
     n_samples_data = data_duration * sampling_rate
+    if float(int(n_samples_data)) == float(n_samples_data):
+        n_samples_data = np.int32(n_samples_data)
+    else:
+        print('The data duration times the sampling rate yields a non-integer number of samples !')
+        print('Adjust your input parameters so that this product is an integer.')
+        return
+
     data = np.random.random_sample((n_stations, n_components, n_samples_data))
     for s in range(n_stations):
         for c in range(n_components):
@@ -204,6 +206,13 @@ def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
 
     # generate templates from data
     n_samples_template = template_duration * sampling_rate
+    if float(int(n_samples_template)) == float(n_samples_template):
+        n_samples_template = np.int32(n_samples_template)
+    else:
+        print('The template duration times the sampling rate yields a non-integer number of samples !')
+        print('Adjust your input parameters so that this product is an integer.')
+        return
+
     n_templates = template_times.size
     templates = np.zeros((n_templates,
                           n_stations,

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -174,6 +174,11 @@ def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
     """
     output: templates, moveouts, data, step, cc_sum
     """
+    if float(int(sampling_rate)) != float(sampling_rate):
+        print('The sampling rate should be an integer !\nCorrect that before running the test function.')
+        return
+    else:
+        sampling_rate = int(sampling_rate)
 
     template_times = np.random.random_sample(n_templates) * (data_duration / 2)
     # if step is not 1, not very likely that random times will be found
@@ -191,14 +196,14 @@ def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
     moveouts = np.round(moveouts * sampling_rate)
 
     # generate data
-    n_samples_data = np.int32(data_duration * sampling_rate)
+    n_samples_data = data_duration * sampling_rate
     data = np.random.random_sample((n_stations, n_components, n_samples_data))
     for s in range(n_stations):
         for c in range(n_components):
             data[s, c, :] = data[s, c, :] - np.mean(data[s, c, :])
 
     # generate templates from data
-    n_samples_template = np.int32(template_duration * sampling_rate)
+    n_samples_template = template_duration * sampling_rate
     n_templates = template_times.size
     templates = np.zeros((n_templates,
                           n_stations,

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -191,14 +191,14 @@ def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
     moveouts = np.round(moveouts * sampling_rate)
 
     # generate data
-    n_samples_data = data_duration * sampling_rate
+    n_samples_data = np.int32(data_duration * sampling_rate)
     data = np.random.random_sample((n_stations, n_components, n_samples_data))
     for s in range(n_stations):
         for c in range(n_components):
             data[s, c, :] = data[s, c, :] - np.mean(data[s, c, :])
 
     # generate templates from data
-    n_samples_template = template_duration * sampling_rate
+    n_samples_template = np.int32(template_duration * sampling_rate)
     n_templates = template_times.size
     templates = np.zeros((n_templates,
                           n_stations,


### PR DESCRIPTION
I think there is a bit of misunderstanding on which bug I am talking about in the test function.

If n_samples_data and n_samples_template are not integer variables, which is currently the case if the user provides a sampling_rate that is not an integer (or just writing sampling_rate=100. instead of sampling_rate=100), then numpy cannot create the data matrix and the template matrix.

You can see this in the following screen shot:
![current_fmf](https://user-images.githubusercontent.com/31778001/39938479-16b8a0da-5521-11e8-8c54-aa9492f8e1bf.png)

My pull request is just a simple correction that makes sure that n_samples_data and n_samples_template are converted to integer variables before creating the arrays.

As you can see, the test function now works perfectly well even if the sampling rate is provided as a float variable.
![modified_fmf_float](https://user-images.githubusercontent.com/31778001/39938555-5454589e-5521-11e8-82ff-09c612d76797.png)

(Note the speedup in the second screen shot, explained by the implementation of the new cumulative sum ! ;) )