### PR TITLE
Remove custom install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,17 +9,20 @@ Minimal setup file for the fast_matched_filter library for Python packaging.
 """
 
 import os
-from setuptools import setup
+from setuptools import setup, Extension
 from setuptools.command.install import install
-from distutils.command.build import build
+from setuptools.command.build_ext import build_ext as build_ext_original
 from subprocess import call
 
 
+class FMFExtension(Extension):
+    def __init__(self, name):
+        # Don't run the default setup-tools build commands, use the custom one
+        super().__init__(name, sources=[])
+
 # Define a new build command
-class FastMatchedFilterBuild(build):
+class FastMatchedFilterBuild(build_ext_original):
     def run(self):
-        # Run standard python build things
-        build.run(self)
         # Build the Python libraries via Makefile
         cpu_make = ['make', 'python_cpu']
         gpu_make = ['make', 'python_gpu']
@@ -39,7 +42,7 @@ class FastMatchedFilterBuild(build):
             raise OSError("Could not build cpu code")
 
 # Get the long description - it won't have md formatting properly without
-# using pandoc though, but that adds another dependancy.
+# using pandoc though, but that adds another dependency.
 with open('README.md') as f:
     long_description = f.read()
 
@@ -64,4 +67,6 @@ setup(name='FastMatchedFilter',
       include_package_data=True,
       zip_safe=False,
       cmdclass={
-          'build': FastMatchedFilterBuild})
+          'build_ext': FastMatchedFilterBuild},
+      ext_modules=[FMFExtension('fast_matched_filter.lib.matched_filter_CPU'),
+                   FMFExtension('fast_matched_filter.lib.matched_filter_GPU')])

--- a/setup.py
+++ b/setup.py
@@ -38,13 +38,6 @@ class FastMatchedFilterBuild(build):
         if cpu_built is False:
             raise OSError("Could not build cpu code")
 
-
-# Define a new install command
-class FastMatchedFilterInstall(install):
-    def run(self):
-        install.run(self)
-
-
 # Get the long description - it won't have md formatting properly without
 # using pandoc though, but that adds another dependancy.
 with open('README.md') as f:
@@ -71,5 +64,4 @@ setup(name='FastMatchedFilter',
       include_package_data=True,
       zip_safe=False,
       cmdclass={
-          'build': FastMatchedFilterBuild,
-          'install': FastMatchedFilterInstall})
+          'build': FastMatchedFilterBuild})


### PR DESCRIPTION
I might be missing something behind why there was a custom install function, but in playing around to make some documentation for EQcorrscan (on how to make use of FMF from EQcorrscan) I realised that the custom installation was not building, so `pip install` did not work without a separate building step first. Without the custom build command, the default install will build the libraries, then install.  
This makes the command:
```bash
pip install git+https://github.com/beridel/fast_matched_filter
```
possible, and will allow for distribution via standard methods (e.g. pypi if you so chose).

Also, question: are you guys okay if I add some docs for how to use FMF from EQcorrscan? Mostly I like this stuff, it is super fast, and I don't plan on re-writing your work! I will provide links to the guthub and the paper in prominent locations and encourage anyone that uses FMF to cite your work.  I'm working on the docs in [this PR](https://github.com/eqcorrscan/EQcorrscan/pull/231) so you can see where I am so far.