### PR TITLE
Don't use super, not supported for py27

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,7 @@ Minimal setup file for the fast_matched_filter library for Python packaging.
     (https://www.gnu.org/licenses/gpl-3.0.en.html)
 """
 
-import os
 from setuptools import setup, Extension
-from setuptools.command.install import install
 from setuptools.command.build_ext import build_ext as build_ext_original
 from subprocess import call
 
@@ -18,7 +16,8 @@ from subprocess import call
 class FMFExtension(Extension):
     def __init__(self, name):
         # Don't run the default setup-tools build commands, use the custom one
-        super().__init__(name, sources=[])
+        Extension.__init__(self, name=name, sources=[])
+
 
 # Define a new build command
 class FastMatchedFilterBuild(build_ext_original):
@@ -40,6 +39,7 @@ class FastMatchedFilterBuild(build_ext_original):
             print("Could not build GPU code")
         if cpu_built is False:
             raise OSError("Could not build cpu code")
+
 
 # Get the long description - it won't have md formatting properly without
 # using pandoc though, but that adds another dependency.


### PR DESCRIPTION
In #20 I didn't test for Python 2.7. Turns out the `super().__init__(name, sources=[])` isn't supported before python 3.  The method employed here should do the trick.

Tested on Python 2.7 and Python 3.6 for:
```bash
python setup.py build_ext
```
with success (on a machine without a GPU, so no GPU compilation).

@ebeauce, can you test this and make sure it fixes the issue, sorry about this - the joys of supporting both Python 2.7 and 3.x.  At some point soon you might want to think about moving away from Python 2.7 (which will stop being developed at the end of 2020, and numpy is stopping feature releases for Python 2.7 in 2019).  The [python3statement](http://python3statement.org/) is worth a look.