### PR TITLE
Limit number of GPUs needed based on number of templates

### DIFF
--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -133,7 +133,7 @@ void matched_filter(float *templates, float *sum_square_templates,
 
     // find the number of available GPUs
     cudaGetDeviceCount(&nGPUs);
-    omp_set_num_threads(nGPUs);
+    omp_set_num_threads(fminf((float)nGPUs, (float)n_templates));
 
     int chunk_size = n_corr/NCHUNKS + 1;
 

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -133,7 +133,7 @@ void matched_filter(float *templates, float *sum_square_templates,
 
     // find the number of available GPUs
     cudaGetDeviceCount(&nGPUs);
-    omp_set_num_threads(fminf((float)nGPUs, (float)n_templates));
+    omp_set_num_threads((int)fminf((float)nGPUs, (float)n_templates));
 
     int chunk_size = n_corr/NCHUNKS + 1;
 

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -133,7 +133,7 @@ void matched_filter(float *templates, float *sum_square_templates,
 
     // find the number of available GPUs
     cudaGetDeviceCount(&nGPUs);
-    omp_set_num_threads((int)fminf((float)nGPUs, (float)n_templates));
+    omp_set_num_threads(min(nGPUS, (int)n_templates));
 
     int chunk_size = n_corr/NCHUNKS + 1;
 


### PR DESCRIPTION
A small change to only use the number of GPUs needs based on the number of templates. Useful for computers without any job manager that handles GPUs.