### PR TITLE
Reducing the block size for the sum_cc kernel seems to improve performances

### DIFF
--- a/fast_matched_filter/__init__.py
+++ b/fast_matched_filter/__init__.py
@@ -15,4 +15,4 @@ del fast_matched_filter
 
 __all__ = [matched_filter, test_matched_filter]
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -285,8 +285,10 @@ void matched_filter(float *templates, float *sum_square_templates,
                 // weighted sum of correlation coefficients
                 cudaMemset(cc_sum_d, 0, sizeof_cc_sum);
 
-                dim3 GS_sum(ceilf(cs / (float)BS.x));
-                sum_cc<<<GS_sum, BS>>>(cc_mat_d, cc_sum_d, weights_d_t, n_stations, n_components, n_corr_t, chunk_offset, cs);
+                // using a small block size seems to improve the speed of sum_cc 
+                dim3 BS_sum(32);
+                dim3 GS_sum(ceilf(cs / (float)BS_sum.x));
+                sum_cc<<<GS_sum, BS_sum>>>(cc_mat_d, cc_sum_d, weights_d_t, n_stations, n_components, n_corr_t, chunk_offset, cs);
 
                 // return an error if something happened in the kernel (and crash the program)
                 gpuErrchk(cudaPeekAtLastError());

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='FastMatchedFilter',
-      version='1.1.0',
+      version='1.2.0',
       description='Fast time-domain normalised cross-correlation for '
                   'CPU & GPU',
       long_description=long_description,


### PR DESCRIPTION
Hello,

I recently realized that stacking the correlation coefficients to get the averaged/summed correlation coefficient takes about the same amount time as for calculating the correlation coefficients. Optimizing the summation operation seems possible, but tricky. However, changing the block size of the sum_cc kernel to a smaller size seems to improve the speed by 15% (what do you get on your machines?). After playing a bit, I observed that 32 threads per block lead to the best improvement. Therefore, I am suggesting we change the block size to 32 (cf. my new branch).

Another unexpected speedup came from changing my nvcc to a newer cuda version. The nvcc from cuda 10 greatly reduces the speed of the network_corr kernel (compared to cuda 7.5).

![FMF_upgrade](https://user-images.githubusercontent.com/31778001/74775043-de6a4300-5262-11ea-9597-702ea1e058d8.png)

Conclusion: Update your version of cuda, and upgrade FMF with this new change and you could observe a speed up of 30%! (and maybe more on your machines)
