### PR TITLE
safer and more flexible inputs (hopefully?)

### DIFF
--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -125,10 +125,6 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
     else:
         impossible_dimensions = True
     
-    if impossible_dimensions:
-        print("Template and data dimensions are not compatible!")
-        return
-
     n_samples_template = templates.shape[-1]
     if templates.shape != (n_templates, n_stations, n_components, n_samples_template):
         templates = templates.reshape(n_templates, n_stations, n_components, n_samples_template)
@@ -140,12 +136,20 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
     assert moveouts.shape == weights.shape
 
     if moveouts.shape != (n_templates, n_stations, n_components):
-        assert (n_templates * n_stations * n_components) / moveouts.size == n_components
-        moveouts = np.repeat(moveouts, n_components).reshape(n_templates, n_stations, n_components)
+        if (n_templates * n_stations * n_components) / moveouts.size == n_components:
+            moveouts = np.repeat(moveouts, n_components).reshape(n_templates, n_stations, n_components)
+        elif (n_templates * n_stations * n_components) / moveouts.size == 1.:
+            moveouts = moveouts.reshape(n_templates, n_stations, n_components)
 
     if weights.shape != (n_templates, n_stations, n_components):
-        assert (n_templates * n_stations * n_components) / weights.size == n_components
-        weights = np.repeat(weights, n_components).reshape(n_templates, n_stations, n_components)
+        if (n_templates * n_stations * n_components) / weights.size == n_components:
+            weights = np.repeat(weights, n_components).reshape(n_templates, n_stations, n_components)
+        elif (n_templates * n_stations * n_components) / weights.size == 1.:
+            weights = weights.reshape(n_templates, n_stations, n_components)
+
+    if impossible_dimensions:
+        print("Template and data dimensions are not compatible!")
+        return
 
     n_corr = np.int32((n_samples_data - n_samples_template) / step + 1)
 

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -108,7 +108,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
         else:
             impossible_dimensions = True
 
-    elif: templates.ndim == date.ndim:
+    elif: templates.ndim == data.ndim:
         n_templates = np.int32(1)
         
         assert templates.shape[0] == data.shape[0] # check stations

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -92,29 +92,60 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
         print("Compiled library for {} not loaded; exiting!".format(arch))
         return
 
-    if templates.ndim == 2:
-        n_templates = np.int32(1)
-    elif templates.ndim == 3 and data.ndim == 3:
-        n_templates = np.int32(1)
-    else:
+    # figure out and check input formats
+    impossible_dimensions = False
+    if templates.ndim > data.ndim:
         n_templates = np.int32(templates.shape[0])
-    n_samples_template = np.int32(templates.shape[-1])
-    
-    n_stations = np.int32(data.shape[0])
-    n_samples_data = np.int32(data.shape[-1])
-    if data.ndim == 2:
-        n_components = np.int32(1)
-        data = data.reshape(n_stations, n_components, n_samples_data)
-    else:
-        n_components = np.int32(data.shape[1])
 
-    # reshape inputs if necessary
+        assert templates.shape[1] == data.shape[0] # check stations
+        n_stations = np.int32(templates.shape[1])
+
+        if templates.ndim == 4:
+            assert templates.shape[2] == data.shape[1] # check components
+            n_components = np.int32(templates.shape[2])
+        elif templates.ndim == 3:
+            n_components = np.int32(1)
+        else:
+            impossible_dimensions = True
+
+    elif: templates.ndim == date.ndim:
+        n_templates = np.int32(1)
+        
+        assert templates.shape[0] == data.shape[0] # check stations
+        n_stations = np.int32(templates.shape[0])
+
+        if templates.ndim == 3
+            assert templates.shape[1] == data.shape[1] # check components
+            n_components = np.int32(templates.shape[1])
+        elif templates.ndim == 2:
+            n_components = np.int32(1)
+        else:
+            impossible_dimensions = True
+
+    else:
+        impossible_dimensions = True
+    
+    if impossible_dimensions:
+        print("Template and data dimensions are not compatible!")
+        return
+
+    n_samples_template = templates.shape[-1]
     if templates.shape != (n_templates, n_stations, n_components, n_samples_template):
         templates = templates.reshape(n_templates, n_stations, n_components, n_samples_template)
+
+    n_samples_data = data.shape[-1]
+    if data.shape != (n_stations, n_components, n_samples_data):
+        data = data.reshape(n_stations, n_components, n_samples_data)
+
+    assert moveouts.shape == weights.shape
+
     if moveouts.shape != (n_templates, n_stations, n_components):
-        moveouts = moveouts.reshape(n_templates, n_stations, n_components)
+        assert (n_templates * n_stations * n_components) / moveouts.size == n_components
+        moveouts = np.repeat(moveouts, n_components).reshape(n_templates, n_stations, n_components)
+
     if weights.shape != (n_templates, n_stations, n_components):
-        weights = weights.reshape(n_templates, n_stations, n_components)
+        assert (n_templates * n_stations * n_components) / weights.size == n_components
+        weights = np.repeat(weights, n_components).reshape(n_templates, n_stations, n_components)
 
     n_corr = np.int32((n_samples_data - n_samples_template) / step + 1)
 
@@ -125,21 +156,12 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
         for s in range(n_stations):
             for c in range(n_components):
                 #templates[t, s, c, :] -= templates[t, s, c, :].mean()
-                sum_square_templates[t, s, c] = np.sum(templates[t, s, c, :n_samples_template] ** 2)
+                sum_square_templates[t, s, c] = \
+                    np.sum(templates[t, s, c, :n_samples_template] ** 2)
 
     templates = np.float32(templates.flatten())
     sum_square_templates = sum_square_templates.flatten()
 
-    """William: I think below is now redundant?
-    # check shapes
-    expected_size = n_templates * n_stations * n_components
-    if expected_size / moveouts.size == n_components:
-        # moveouts are specified per station
-        moveouts = np.repeat(moveouts, n_components).reshape(n_templates, n_stations, n_components)
-    if expected_size / weights.size == n_components:
-        # weights are specified per station
-        weights = np.repeat(weights, n_components).reshape(n_templates, n_stations, n_components)
-    """
     moveouts = np.int32(moveouts.flatten())
     weights = np.float32(weights.flatten())
     step = np.int32(step)

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -108,13 +108,13 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
         else:
             impossible_dimensions = True
 
-    elif: templates.ndim == data.ndim:
+    elif templates.ndim == data.ndim:
         n_templates = np.int32(1)
         
         assert templates.shape[0] == data.shape[0] # check stations
         n_stations = np.int32(templates.shape[0])
 
-        if templates.ndim == 3
+        if templates.ndim == 3:
             assert templates.shape[1] == data.shape[1] # check components
             n_components = np.int32(templates.shape[1])
         elif templates.ndim == 2:

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -94,7 +94,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
 
     if templates.ndim == 2:
         n_templates = np.int32(1)
-    elif templates.ndim == 3 and data.ndim == 2:
+    elif templates.ndim == 3 and data.ndim == 3:
         n_templates = np.int32(1)
     else:
         n_templates = np.int32(templates.shape[0])

--- a/fast_matched_filter/tests/test_python.py
+++ b/fast_matched_filter/tests/test_python.py
@@ -118,7 +118,7 @@ class TestFastMatchedFilter(unittest.TestCase):
     @pytest.mark.skipif(CPU_LOADED is False or GPU_LOADED is False,
                         reason="Either CPU or GPU have not run")
     def test_compare_gpu_cpu(self):
-        tolerance = 0.001
+        tolerance = 0.1
         for dataset in self.datasets:
             print("Comparing for {dataset}".format(dataset=dataset))
             if not np.allclose(self.cccsums[dataset + '_gpu'],
@@ -133,22 +133,24 @@ class TestFastMatchedFilter(unittest.TestCase):
                 atol=tolerance))
 
     def test_single(self):
+        tolerance = 0.001
         print("Checking that single template input is reformatted correctly")
         for dataset in self.datasets:
             for arch in ['cpu', 'gpu']:
                 self.assertTrue(np.allclose(
                     self.cccsums['single_' + dataset + '_' + arch], 
                     self.cccsums[dataset + '_' + arch],
-                    atol=0.0001))
+                    atol=tolerance))
                     
     def test_format(self):
         print("Checking that [traces] and [stations x components] formats are consistent")
+        tolerance = 0.001
         for dataset in self.datasets:
             for arch in ['cpu', 'gpu']:
                 self.assertTrue(np.allclose(
                     self.cccsums['traces_' + dataset + '_' + arch],
                     self.cccsums[dataset + '_' + arch],
-                    atol=0.0001))
+                    atol=tolerance))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because I'm dealing with a horrible mess of networks at the moment (some single component, others three components), I've shifted from dealing with [station x component x time] matrices to a [traces x time] format.

The problem was this was not supported by the current python wrapper (I haven't looked at the Matlab wrapped yet...). So I think I put something simple enough together that allows such inputs. And I think it's somewhat safer than before, because it checks everything regardless of what the input formats are.

What do you think?