### PR TITLE
initial try at removing sum_square_templates

### DIFF
--- a/fast_matched_filter/fast_matched_filter.m
+++ b/fast_matched_filter/fast_matched_filter.m
@@ -28,7 +28,6 @@ n_templates = size(templates, 4);
 n_samples_data = size(data, 1);
 n_corr = floor((n_samples_data - n_samples_template) / step + 1);
 
-sum_square_templates = squeeze(sum(templates .^ 2, 1));
 
 % extend the moveouts and weights matrices from 2D to 3D matrices, if necessary
 b = ones(n_components, 1);
@@ -38,6 +37,13 @@ end
 if numel(weights) ~= n_components * n_stations * n_templates
     weights = reshape(kron(weights, b), [n_components, n_stations, n_templates]);
 end
+
+for t = 1:n_templates
+    for s = 1:n_stations
+        for c = 1:n_components
+            templates(:,c,s,t) = templates(:,c,s,t) - mean(templates(:,c,s,t))
+            templates(:,c,s,t) = templates(:,c,s,t) / max(abs(templates(:,c,s,t))
+            templates(:,c,s,t) = templates(:,c,s,t) / sqrt(sum(templates(:,c,s,t) .^ 2))
 
 % input arguments (brackets indicate a non-scalar variable):
 % templates (float) [time x components x stations x templates]
@@ -57,7 +63,6 @@ end
 % cc_sum (float)
 
 templates = single(templates(:));
-sum_square_templates = single(sum_square_templates(:));
 moveouts = int32(moveouts(:));
 data = single(data(:));
 weights = single(weights(:));
@@ -70,7 +75,6 @@ n_components = int32(n_components);
 n_corr = int32(n_corr);
 
 cc_sum = matched_filter(templates, ...
-                        sum_square_templates, ...
                         moveouts, ...
                         data, ...
                         weights, ...

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -33,6 +33,19 @@ try:
         ct.c_size_t,               # n_components
         ct.c_size_t,               # n_corr
         ct.POINTER(ct.c_float)]    # cc_sums
+    _libCPU.matched_filter_precise.argtypes = [
+        ct.POINTER(ct.c_float),    # templates
+        ct.POINTER(ct.c_int),      # moveouts
+        ct.POINTER(ct.c_float),    # data
+        ct.POINTER(ct.c_float),    # weights
+        ct.c_size_t,               # step
+        ct.c_size_t,               # n_samples_template
+        ct.c_size_t,               # n_samples_data
+        ct.c_size_t,               # n_templates
+        ct.c_size_t,               # n_stations
+        ct.c_size_t,               # n_components
+        ct.c_size_t,               # n_corr
+        ct.POINTER(ct.c_float)]    # cc_sums
     CPU_LOADED = True
 except OSError:
     print("Matched-filter CPU is not compiled! Should be here: {}".
@@ -81,6 +94,8 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
     """
 
     if arch.lower() == 'cpu' and CPU_LOADED is False:
+        loaded = False
+    if arch.lower() == 'precise' and CPU_LOADED is False:
         loaded = False
     elif arch.lower() == 'gpu' and GPU_LOADED is False:
         loaded = False
@@ -172,6 +187,21 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
 
     if arch == 'cpu':
         _libCPU.matched_filter(
+            templates.ctypes.data_as(ct.POINTER(ct.c_float)),
+            moveouts.ctypes.data_as(ct.POINTER(ct.c_int)),
+            data.ctypes.data_as(ct.POINTER(ct.c_float)),
+            weights.ctypes.data_as(ct.POINTER(ct.c_float)),
+            step,
+            n_samples_template,
+            n_samples_data,
+            n_templates,
+            n_stations,
+            n_components,
+            n_corr,
+            cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)))
+
+    if arch == 'cpu':
+        _libCPU.matched_filter_precise(
             templates.ctypes.data_as(ct.POINTER(ct.c_float)),
             moveouts.ctypes.data_as(ct.POINTER(ct.c_int)),
             data.ctypes.data_as(ct.POINTER(ct.c_float)),

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -55,7 +55,7 @@ void matched_filter(float *templates, int *moveouts,
         weights_t = weights + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = n_samples_data - n_samples_template - max_moveout - step;
+        stop_i = n_samples_data - n_samples_template - max_moveout;
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -167,3 +167,116 @@ void neumaier_cumsum_squared(float *array, int length, double *cumsum) {
     }
 }
 
+//-------------------------------------------------------------------------
+void matched_filter_precise(float *templates, int *moveouts,
+                            float *data, 
+                            float *weights, int step, int n_samples_template, int n_samples_data,
+                            int n_templates, int n_stations, int n_components, int n_corr,
+                            float *cc_sum) { // output variable
+
+    int t, ch, i;
+    int start_i, stop_i, cc_i;
+    int min_moveout, max_moveout;
+    int network_offset, station_offset, cc_sum_offset;
+    int *moveouts_t = NULL;
+    float *sum_square_template = NULL, *templates_t = NULL, *weights_t = NULL;
+
+    sum_square_template = malloc((n_stations * n_components) * sizeof(double));
+
+    // run matched filter template by template
+    for (t = 0; t < n_templates; t++) {
+        network_offset = t * n_stations * n_components;
+        station_offset = t * n_stations;
+        cc_sum_offset = t * n_corr;
+        
+        // find min/max moveout and template vector position
+        min_moveout = 0;
+        max_moveout = 0;
+        for (ch = 0; ch < (n_stations * n_components); ch++) {
+            if (moveouts[network_offset + ch] < min_moveout) min_moveout = moveouts[network_offset + ch];
+            if (moveouts[network_offset + ch] > max_moveout) max_moveout = moveouts[network_offset + ch];
+        }
+    
+        templates_t = templates + network_offset * n_samples_template;
+        moveouts_t = moveouts + network_offset;
+        weights_t = weights + network_offset;
+
+        // compute sum of squares for template
+        memset(sum_square_template, 0., (n_stations * n_components) * sizeof(double));
+        for (ch = 0; ch < (n_stations * n_components); ch++) {
+            for (i = 0; i < n_samples_template; i++) {
+                sum_square_template[ch] +=  templates_t[i];
+            }
+        }
+
+        start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
+        stop_i = n_samples_data - n_samples_template - max_moveout - step;
+
+#pragma omp parallel for private(i, cc_i)
+        for (i = start_i; i < stop_i; i += step) {
+            cc_i = i / step;
+            cc_sum[cc_sum_offset + cc_i] = network_corr_precise(templates_t,
+                                                                sum_square_template,
+                                                                moveouts_t,
+                                                                data + i,
+                                                                weights_t,
+                                                                n_samples_template,
+                                                                n_samples_data,
+                                                                n_stations,
+                                                                n_components);
+        }
+    }
+
+    free(sum_square_template);
+}
+ 
+//-------------------------------------------------------------------------
+float network_corr_precise(float *templates, float *sum_square_template, int *moveouts,
+                   float *data, float *weights,
+                   int n_samples_template, int n_samples_data, int n_stations, int n_components) {
+
+    int s, c, d, dd, t;
+    int station_offset, component_offset;
+    float cc, cc_sum = 0; // output
+ 
+    for (s = 0; s < n_stations; s++) {
+        
+        station_offset = s * n_components;
+
+        cc = 0;        
+        for (c = 0; c < n_components; c++) {
+            component_offset = station_offset + c;
+            if (weights[component_offset] == 0) continue;
+
+            t  = component_offset * n_samples_template;
+            d  = component_offset * n_samples_data + moveouts[component_offset];
+            dd = component_offset * (n_samples_data + 1) + moveouts[component_offset];
+            
+            cc = corrc_precise(templates + t,
+                               sum_square_template[component_offset],
+                               data + d,
+                               n_samples_template);
+            cc_sum += cc * weights[component_offset];
+        }
+    }
+    
+    return cc_sum;
+}
+ 
+//-------------------------------------------------------------------------
+float corrc_precise(float *templates, float sum_square_template,
+            float *data, 
+            int n_samples_template) {
+
+    int i;
+    float numerator = 0, sum_square_data = 0, denominator = 0, cc = 0;
+    
+    for (i = 0; i < n_samples_template; i++){
+        numerator += templates[i] * data[i];
+        sum_square_data += data[i] * data[i];
+    }
+    denominator = sqrt(sum_square_template * sum_square_data);
+
+    if (denominator > STABILITY_THRESHOLD) cc = numerator / denominator;
+    return cc;
+}

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -1,5 +1,5 @@
-void matched_filter(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
-float network_corr(float*, float*, int*, float*, double*, float*, int, int, int, int);
-float corrc(float*, float, float*, double*, int);
+void matched_filter(float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
+float network_corr(float*, int*, float*, double*, float*, int, int, int, int);
+float corrc(float*, float*, double*, int);
 void cumsum_square_data(float*, int, float*, int, int, double*);
 void neumaier_cumsum_squared(float*, int, double*);

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -3,3 +3,6 @@ float network_corr(float*, int*, float*, double*, float*, int, int, int, int);
 float corrc(float*, float*, double*, int);
 void cumsum_square_data(float*, int, float*, int, int, double*);
 void neumaier_cumsum_squared(float*, int, double*);
+void matched_filter_precise(float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
+float network_corr_precise(float*, float*, int*, float*, float*,int, int, int, int);
+float corrc_precise(float*, float, float*, int);

--- a/fast_matched_filter/src/matched_filter_GPU.h
+++ b/fast_matched_filter/src/matched_filter_GPU.h
@@ -1,1 +1,1 @@
-void matched_filter(float*, float*, int*, float*, float*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, float*);
+void matched_filter(float*, int*, float*, float*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, float*);

--- a/fast_matched_filter/src/matched_filter_mex.c
+++ b/fast_matched_filter/src/matched_filter_mex.c
@@ -13,7 +13,7 @@
 
 void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray *ptrInputs[])
 {
-    float *templates = NULL, *sum_square_templates = NULL; // template input
+    float *templates = NULL;  // template input
     int *moveouts = NULL, max_moveout = 0; // template moveout
     float *data = NULL; // data input
     double *square_data, *csum_square_data = NULL;
@@ -25,10 +25,9 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
     int data_offset;
     
     /* check for good number of inputs/outputs */
-    if (nInputs != 12)
+    if (nInputs != 11)
         mexErrMsgIdAndTxt("Matlab:matched_filter.c", "Twelve inputs required: \
                  templates (float*), \
-                 sum_square_templates (float*), \
                  moveouts (int*), \
                  data (float*), \
                  csum_square_data_f (float*), \
@@ -47,17 +46,16 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
     
     /* read in inputs */
     templates = (float*)mxGetData(ptrInputs[0]);
-    sum_square_templates = (float*)mxGetData(ptrInputs[1]);
-    moveouts = (int*)mxGetData(ptrInputs[2]);
-    data = (float*)mxGetData(ptrInputs[3]);
-    weights = (float*)mxGetData(ptrInputs[4]);
-    step = (int)mxGetScalar(ptrInputs[5]);
-    n_samples_template = (int)mxGetScalar(ptrInputs[6]);
-    n_samples_data = (int)mxGetScalar(ptrInputs[7]);
-    n_templates = (int)mxGetScalar(ptrInputs[8]);
-    n_stations = (int)mxGetScalar(ptrInputs[9]);
-    n_components = (int)mxGetScalar(ptrInputs[10]);
-    n_corr = (int)mxGetScalar(ptrInputs[11]);
+    moveouts = (int*)mxGetData(ptrInputs[1]);
+    data = (float*)mxGetData(ptrInputs[2]);
+    weights = (float*)mxGetData(ptrInputs[3]);
+    step = (int)mxGetScalar(ptrInputs[4]);
+    n_samples_template = (int)mxGetScalar(ptrInputs[5]);
+    n_samples_data = (int)mxGetScalar(ptrInputs[6]);
+    n_templates = (int)mxGetScalar(ptrInputs[7]);
+    n_stations = (int)mxGetScalar(ptrInputs[8]);
+    n_components = (int)mxGetScalar(ptrInputs[9]);
+    n_corr = (int)mxGetScalar(ptrInputs[10]);
 
     /* prepare outputs */
     const mwSize n_samples_out = n_corr * n_templates;
@@ -66,7 +64,6 @@ void mexFunction(int nOutputs, mxArray *ptrOutputs[], int nInputs, const mxArray
     
     /* and do the math */
     matched_filter(templates,
-                   sum_square_templates,
                    moveouts,
                    data,
                    weights,

--- a/fast_matched_filter/tests/test_python.py
+++ b/fast_matched_filter/tests/test_python.py
@@ -118,7 +118,7 @@ class TestFastMatchedFilter(unittest.TestCase):
     @pytest.mark.skipif(CPU_LOADED is False or GPU_LOADED is False,
                         reason="Either CPU or GPU have not run")
     def test_compare_gpu_cpu(self):
-        tolerance = 0.1
+        tolerance = 0.01
         for dataset in self.datasets:
             print("Comparing for {dataset}".format(dataset=dataset))
             if not np.allclose(self.cccsums[dataset + '_gpu'],


### PR DESCRIPTION
So I've gone ahead and normalized the templates so that the sum of their squares is 1. A lot of little changes that reach into many files...

This definitely needs some more serious testing to make sure it doesn't screw anything up. This might actually be the pull request to evaluate the accuracy of the everything. I was considering one way to do that would be to pre-calculate a CC sum time series using the slowest, most accurate possible (still just using singles though), include that in the test data, and comparing the calculated CC sum time series on CPU and GPU to that one, which acts as the "gold standard".

What do you think @ebeauce and @calum-chamberlain ?