### PR TITLE
The CPU code stopped calculating the CCs (step) sample(s) before the …

### DIFF
--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -56,7 +56,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = n_samples_data - n_samples_template - max_moveout - step;
+        stop_i = n_samples_data - n_samples_template - max_moveout;
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {


### PR DESCRIPTION
Hi,

Following your tests comparing gpu vs cpu, I thought it was weird to get such a discrepancy between the two (I guess I have more faith in our codes than you do!). After adding a few more print statements, I realized that this discrepancy occurred at the end of the time series, when the CPU code stops one step before the GPU code.

I modified the definition of the "stop_i" variable in matched_filter.c so that it continues calculating until the end of the time series. I don't think the "- step" was necessary since the loop stops at i < stop_i  = n_samples_data - n_samples_template - max_moveout (i.e. stop_i is a valid position, and we still stop before).

PS: I think it is time to clean up all the branches other than master...