### PR TITLE
Initial implementation of a precise CPU matched-filter

### DIFF
--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -170,3 +170,105 @@ void neumaier_cumsum_squared(float *array, int length, double *cumsum) {
     }
 }
 
+//-------------------------------------------------------------------------
+void matched_filter_precise(float *templates, float *sum_square_templates, int *moveouts,
+                            float *data,
+                            float *weights, int step, int n_samples_template, int n_samples_data,
+                            int n_templates, int n_stations, int n_components, int n_corr,
+                            float *cc_sum) { // output variable
+
+    int t, ch, i;
+    int start_i, stop_i, cc_i;
+    int min_moveout, max_moveout;
+    int network_offset, station_offset, cc_sum_offset;
+    int *moveouts_t = NULL;
+    float *templates_t = NULL, *sum_square_templates_t = NULL, *weights_t = NULL;
+
+    // run matched filter template by template
+    for (t = 0; t < n_templates; t++) {
+        network_offset = t * n_stations * n_components;
+        station_offset = t * n_stations;
+        cc_sum_offset = t * n_corr;
+
+        // find min/max moveout and template vector position
+        min_moveout = 0;
+        max_moveout = 0;
+        for (ch = 0; ch < (n_stations * n_components); ch++) {
+            if (moveouts[network_offset + ch] < min_moveout) min_moveout = moveouts[network_offset + ch];
+            if (moveouts[network_offset + ch] > max_moveout) max_moveout = moveouts[network_offset + ch];
+        }
+
+        templates_t = templates + network_offset * n_samples_template;
+        moveouts_t = moveouts + network_offset;
+        weights_t = weights + network_offset;
+        sum_square_templates_t = sum_square_templates + network_offset;
+
+        start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
+        stop_i = n_samples_data - n_samples_template - max_moveout;
+
+#pragma omp parallel for private(i, cc_i)
+        for (i = start_i; i < stop_i; i += step) {
+            cc_i = i / step;
+            cc_sum[cc_sum_offset + cc_i] = network_corr_precise(templates_t,
+                                                                sum_square_templates_t,
+                                                                moveouts_t,
+                                                                data + i,
+                                                                weights_t,
+                                                                n_samples_template,
+                                                                n_samples_data,
+                                                                n_stations,
+                                                                n_components);
+        }
+    }
+}
+
+//-------------------------------------------------------------------------
+float network_corr_precise(float *templates, float *sum_square_template, int *moveouts,
+                   float *data, float *weights,
+                   int n_samples_template, int n_samples_data, int n_stations, int n_components) {
+
+    int s, c, d, dd, t;
+    int station_offset, component_offset;
+    float cc, cc_sum = 0; // output
+
+    for (s = 0; s < n_stations; s++) {
+
+        station_offset = s * n_components;
+
+        cc = 0;
+        for (c = 0; c < n_components; c++) {
+            component_offset = station_offset + c;
+            if (weights[component_offset] == 0) continue;
+
+            t  = component_offset * n_samples_template;
+            d  = component_offset * n_samples_data + moveouts[component_offset];
+            dd = component_offset * (n_samples_data + 1) + moveouts[component_offset];
+
+            cc = corrc_precise(templates + t,
+                               sum_square_template[component_offset],
+                               data + d,
+                               n_samples_template);
+            cc_sum += cc * weights[component_offset];
+        }
+    }
+
+    return cc_sum;
+}
+
+//-------------------------------------------------------------------------
+float corrc_precise(float *templates, float sum_square_template,
+            float *data,
+            int n_samples_template) {
+
+    int i;
+    float numerator = 0, sum_square_data = 0, denominator = 0, cc = 0;
+
+    for (i = 0; i < n_samples_template; i++){
+        numerator += templates[i] * data[i];
+        sum_square_data += data[i] * data[i];
+    }
+    denominator = sqrt(sum_square_template * sum_square_data);
+
+    if (denominator > STABILITY_THRESHOLD) cc = numerator / denominator;
+    return cc;
+}

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -3,3 +3,6 @@ float network_corr(float*, float*, int*, float*, double*, float*, int, int, int,
 float corrc(float*, float, float*, double*, int);
 void cumsum_square_data(float*, int, float*, int, int, double*);
 void neumaier_cumsum_squared(float*, int, double*);
+void matched_filter_precise(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
+float network_corr_precise(float*, float*, int*, float*, float*, int, int, int, int);
+float corrc_precise(float*, float, float*, int);


### PR DESCRIPTION
So here's a precise matched-filter for CPU. You can access it as arch='precise'.

At least on my compute node, the GPU and CPU are pretty much exactly the same now. And it seems that it goes just as fast as the current CPU implementation... But would you mind testing it on your machines to see if there's no difference for you as well?