### PR TITLE
The error message should be returned as soon as the dimensions are id…

### DIFF
--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -148,7 +148,11 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
 
     else:
         impossible_dimensions = True
-    
+
+    if impossible_dimensions:
+        print("Template and data dimensions are not compatible!")
+        return
+   
     n_samples_template = templates.shape[-1]
     if templates.shape != (n_templates, n_stations, n_components, n_samples_template):
         templates = templates.reshape(n_templates, n_stations, n_components, n_samples_template)
@@ -170,10 +174,6 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu'):
             weights = np.repeat(weights, n_components).reshape(n_templates, n_stations, n_components)
         elif (n_templates * n_stations * n_components) / weights.size == 1.:
             weights = weights.reshape(n_templates, n_stations, n_components)
-
-    if impossible_dimensions:
-        print("Template and data dimensions are not compatible!")
-        return
 
     n_corr = np.int32((n_samples_data - n_samples_template) / step + 1)
 


### PR DESCRIPTION
I moved the error message since it was called too late in the code: when dimensions are indeed identified as "impossible", then the bit of code before printing the error message will trigger an error, without printing the message. Therefore I move the print statement so that the program ends properly when it's needed.