### PR TITLE
Correlation length and full normalisation

### DIFF
--- a/fast_matched_filter/__init__.py
+++ b/fast_matched_filter/__init__.py
@@ -15,4 +15,4 @@ del fast_matched_filter
 
 __all__ = [matched_filter, test_matched_filter]
 
-__version__ = '1.3.1'
+__version__ = '1.4.0'

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -78,7 +78,8 @@ except OSError:
     GPU_LOADED = False
 
 
-def matched_filter(templates, moveouts, weights, data, step, arch='cpu', check_zeros='first'):
+def matched_filter(templates, moveouts, weights, data, step, arch='cpu', 
+                   check_zeros='first', normalize="naive"):
     """
     input:
     templates ---------- 4D numpy array [templates x stations x
@@ -104,6 +105,9 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu', check_z
                          'all': Check zeros on each template's CCs. It can be useful
                          for troubleshooting but in general this would
                          print too many messages.
+    normalize ---------- Either "naive" or "full" - full is slower but removes
+                         the mean of the data at every correlation. Naive
+                         is the original implementation.
 
     NB: Mean and trend MUST be removed from template and data traces before
         using this function
@@ -111,6 +115,12 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu', check_z
     output:
     2D numpy array (np.float32) [templates x time (at step defined interval)]
     """
+    assert normalize in ("naive", "full"), "Only know naive or full normalization methods"
+    if normalize == "full":
+        normalize = 1
+        assert arch != "cpu", "Full normalization not supported with cpu arch - try arch=precise"
+    else:
+        normalize = 0
 
     if arch.lower() == 'cpu' and CPU_LOADED is False:
         loaded = False
@@ -230,7 +240,8 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu', check_z
             n_stations,
             n_components,
             n_corr,
-            cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)))
+            cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)),
+            normalize)
     
     elif arch == 'gpu':
         _libGPU.matched_filter(
@@ -246,7 +257,8 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu', check_z
                 n_stations,
                 n_components,
                 n_corr,
-                cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)))
+                cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)),
+                normalize)
 
     cc_sums = cc_sums.reshape((n_templates, n_corr))
     # check for zeros in the CC time series more or less thoroughly

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -79,7 +79,7 @@ except OSError:
 
 
 def matched_filter(templates, moveouts, weights, data, step, arch='cpu', 
-                   check_zeros='first', normalize="naive"):
+                   check_zeros='first', normalize='short'):
     """
     input:
     templates ---------- 4D numpy array [templates x stations x
@@ -105,7 +105,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu',
                          'all': Check zeros on each template's CCs. It can be useful
                          for troubleshooting but in general this would
                          print too many messages.
-    normalize ---------- Either "naive" or "full" - full is slower but removes
+    normalize ---------- Either "short" or "full" - full is slower but removes
                          the mean of the data at every correlation. Naive
                          is the original implementation.
 
@@ -115,7 +115,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu',
     output:
     2D numpy array (np.float32) [templates x time (at step defined interval)]
     """
-    assert normalize in ("naive", "full"), "Only know naive or full normalization methods"
+    assert normalize in ("short", "full"), "Only know short or full normalization methods"
     if normalize == "full":
         normalize = 1
         assert arch != "cpu", "Full normalization not supported with cpu arch - try arch=precise"

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -106,11 +106,11 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu',
                          for troubleshooting but in general this would
                          print too many messages.
     normalize ---------- Either "short" or "full" - full is slower but removes
-                         the mean of the data at every correlation. Naive
+                         the mean of the data at every correlation. Short
                          is the original implementation.
 
-    NB: Mean and trend MUST be removed from template and data traces before
-        using this function
+    NB: When using normalize="short", the templates and the data sliding windows
+        must have zero means (high-pass filter the data if necessary).
 
     output:
     2D numpy array (np.float32) [templates x time (at step defined interval)]

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -56,7 +56,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = 1 + (n_samples_data - n_samples_template - max_moveout);
+        stop_i = 1 + (n_samples_data - n_samples_template); // - max_moveout);
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {
@@ -70,7 +70,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
                                                         n_samples_template,
                                                         n_samples_data,
                                                         n_stations,
-                                                        n_components);
+                                                        n_components, i);
         }
     }
 
@@ -80,7 +80,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
 //-------------------------------------------------------------------------
 float network_corr(float *templates, float *sum_square_template, int *moveouts,
                    float *data, double *csum_square_data, float *weights,
-                   int n_samples_template, int n_samples_data, int n_stations, int n_components) {
+                   int n_samples_template, int n_samples_data, int n_stations, int n_components, int i) {
 
     int s, c, d, dd, t;
     int station_offset, component_offset;
@@ -94,6 +94,8 @@ float network_corr(float *templates, float *sum_square_template, int *moveouts,
         for (c = 0; c < n_components; c++) {
             component_offset = station_offset + c;
             if (weights[component_offset] == 0) continue;
+
+            if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
 
             t  = component_offset * n_samples_template;
             d  = component_offset * n_samples_data + moveouts[component_offset];
@@ -204,7 +206,7 @@ void matched_filter_precise(float *templates, float *sum_square_templates, int *
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = 1 + (n_samples_data - n_samples_template - max_moveout);
+        stop_i = 1 + (n_samples_data - n_samples_template); // - max_moveout);
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {
@@ -217,15 +219,16 @@ void matched_filter_precise(float *templates, float *sum_square_templates, int *
                                                                 n_samples_template,
                                                                 n_samples_data,
                                                                 n_stations,
-                                                                n_components);
+                                                                n_components, i);
         }
     }
 }
 
 //-------------------------------------------------------------------------
-float network_corr_precise(float *templates, float *sum_square_template, int *moveouts,
-                   float *data, float *weights,
-                   int n_samples_template, int n_samples_data, int n_stations, int n_components) {
+float network_corr_precise(
+    float *templates, float *sum_square_template, int *moveouts,
+    float *data, float *weights, int n_samples_template, int n_samples_data, 
+    int n_stations, int n_components, int i) {
 
     int s, c, d, dd, t;
     int station_offset, component_offset;
@@ -239,6 +242,8 @@ float network_corr_precise(float *templates, float *sum_square_template, int *mo
         for (c = 0; c < n_components; c++) {
             component_offset = station_offset + c;
             if (weights[component_offset] == 0) continue;
+
+            if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
 
             t  = component_offset * n_samples_template;
             d  = component_offset * n_samples_data + moveouts[component_offset];

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -56,7 +56,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = 1 + (n_samples_data - n_samples_template - max_moveout);
+        stop_i = n_samples_data - n_samples_template - max_moveout;
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {
@@ -122,7 +122,7 @@ float corrc(float *templates, float sum_square_template,
     for (i = 0; i < n_samples_template; i++){
         numerator += templates[i] * data[i];
     }
-    denominator = sum_square_template * (float)(csum_square_data[n_samples_template - 1] - csum_square_data[-1]);
+    denominator = sum_square_template * (float)(csum_square_data[n_samples_template] - csum_square_data[-1]);
 
     if (denominator > STABILITY_THRESHOLD) cc = numerator / sqrt(denominator);
     return cc;
@@ -204,7 +204,7 @@ void matched_filter_precise(float *templates, float *sum_square_templates, int *
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = 1 + (n_samples_data - n_samples_template - max_moveout);
+        stop_i = n_samples_data - n_samples_template - max_moveout;
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {
@@ -269,6 +269,6 @@ float corrc_precise(float *templates, float sum_square_template,
     }
     denominator = sqrt(sum_square_template * sum_square_data);
 
-    if (denominator > STABILITY_THRESHOLD){ cc = numerator / denominator; }
+    if (denominator > STABILITY_THRESHOLD) cc = numerator / denominator;
     return cc;
 }

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -56,7 +56,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = n_samples_data - n_samples_template - max_moveout;
+        stop_i = 1 + (n_samples_data - n_samples_template - max_moveout);
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {
@@ -122,7 +122,7 @@ float corrc(float *templates, float sum_square_template,
     for (i = 0; i < n_samples_template; i++){
         numerator += templates[i] * data[i];
     }
-    denominator = sum_square_template * (float)(csum_square_data[n_samples_template] - csum_square_data[-1]);
+    denominator = sum_square_template * (float)(csum_square_data[n_samples_template - 1] - csum_square_data[-1]);
 
     if (denominator > STABILITY_THRESHOLD) cc = numerator / sqrt(denominator);
     return cc;
@@ -204,7 +204,7 @@ void matched_filter_precise(float *templates, float *sum_square_templates, int *
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = n_samples_data - n_samples_template - max_moveout;
+        stop_i = 1 + (n_samples_data - n_samples_template - max_moveout);
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {
@@ -269,6 +269,6 @@ float corrc_precise(float *templates, float sum_square_template,
     }
     denominator = sqrt(sum_square_template * sum_square_data);
 
-    if (denominator > STABILITY_THRESHOLD) cc = numerator / denominator;
+    if (denominator > STABILITY_THRESHOLD){ cc = numerator / denominator; }
     return cc;
 }

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -57,7 +57,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = 1 + (n_samples_data - n_samples_template); // - max_moveout);
+        stop_i = 1 + (n_samples_data - n_samples_template - max_moveout);
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {
@@ -71,7 +71,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
                                                         n_samples_template,
                                                         n_samples_data,
                                                         n_stations,
-                                                        n_components, i);
+                                                        n_components);
         }
     }
 
@@ -81,8 +81,7 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
 //-------------------------------------------------------------------------
 float network_corr(float *templates, float *sum_square_template, int *moveouts,
                    float *data, double *csum_square_data, float *weights,
-                   int n_samples_template, int n_samples_data, int n_stations, int n_components, 
-                   int i) {
+                   int n_samples_template, int n_samples_data, int n_stations, int n_components) {
 
     int s, c, d, dd, t;
     int station_offset, component_offset;
@@ -97,7 +96,7 @@ float network_corr(float *templates, float *sum_square_template, int *moveouts,
             component_offset = station_offset + c;
             if (weights[component_offset] == 0) continue;
 
-            if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
+            // if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
 
             t  = component_offset * n_samples_template;
             d  = component_offset * n_samples_data + moveouts[component_offset];
@@ -209,7 +208,7 @@ void matched_filter_precise(float *templates, float *sum_square_templates, int *
         sum_square_templates_t = sum_square_templates + network_offset;
 
         start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
-        stop_i = 1 + (n_samples_data - n_samples_template); // - max_moveout);
+        stop_i = 1 + (n_samples_data - n_samples_template - max_moveout);
 
 #pragma omp parallel for private(i, cc_i)
         for (i = start_i; i < stop_i; i += step) {
@@ -223,7 +222,7 @@ void matched_filter_precise(float *templates, float *sum_square_templates, int *
                                                                 n_samples_data,
                                                                 n_stations,
                                                                 n_components, 
-                                                                i, normalize);
+                                                                normalize);
         }
     }
 }
@@ -232,7 +231,7 @@ void matched_filter_precise(float *templates, float *sum_square_templates, int *
 float network_corr_precise(
     float *templates, float *sum_square_template, int *moveouts,
     float *data, float *weights, int n_samples_template, int n_samples_data, 
-    int n_stations, int n_components, int i, int normalize) {
+    int n_stations, int n_components, int normalize) {
 
     int s, c, d, dd, t;
     int station_offset, component_offset;
@@ -247,7 +246,7 @@ float network_corr_precise(
             component_offset = station_offset + c;
             if (weights[component_offset] == 0) continue;
 
-            if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
+            // if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
 
             t  = component_offset * n_samples_template;
             d  = component_offset * n_samples_data + moveouts[component_offset];

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -90,7 +90,7 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
             __syncthreads(); // make sure the waveforms are read before keep going
 
             // calculate correlation coefficient
-            if (last_sample_trace <= n_samples_data){
+            if (last_sample_trace < n_samples_data){
                 // if not, corresponds to an ill-defined CC with some samples out of the bounds
                 for(i = 0; i < n_samples_template; i++) {
                     data_sample = data_s[i + threadIdx.x * step];

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -256,8 +256,7 @@ void matched_filter(float *templates, float *sum_square_templates,
             for (int i = 0; i < (n_stations * n_components); i++) {
                 max_moveout = (moveouts_t[i] > max_moveout) ? moveouts_t[i] : max_moveout;
             }
-            // n_corr_t = (n_samples_data - n_samples_template - max_moveout) / step + 1;
-            n_corr_t = (n_samples_data - n_samples_template) / step + 1;
+            n_corr_t = (n_samples_data - n_samples_template - max_moveout) / step + 1;
 
             // local pointers on the device
             templates_d_t = templates_d + t_thread * n_samples_template * n_stations * n_components;
@@ -275,6 +274,11 @@ void matched_filter(float *templates, float *sum_square_templates,
                 else{
                     cs = chunk_size;
                 }
+                if (cs <= 0){
+                    // Reached end of valid correlation space.
+                    continue;
+                }
+                printf("cs: %i\n", cs);
                 //sizeof_cc_mat = sizeof(float) * cs * n_stations * n_components;
                 size_t sizeof_cc_sum_chunk = sizeof(float) * cs;
 

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -36,13 +36,13 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
                              size_t step, size_t n_samples_template, size_t n_samples_data,
                              size_t n_stations, size_t n_components,
                              int chunk_offset, int chunk_size,
-                             float *cc_mat) {
+                             float *cc_mat, int normalize) {
   
     // each thread matches the template to one time in the data
     int idx, first_sample_block, first_sample_trace, last_sample_trace; // sample's index
     int i, s, c; // counters
     int data_offset, templates_offset, sum_square_template_offset, cc_mat_offset;
-    float numerator, denominator, sum_square_data;
+    float numerator, denominator, sum_square_data, mean_data;
     float data_sample;
     int t_idx;
 
@@ -70,6 +70,7 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
 
             // initialize sums
             sum_square_data = 0.0f;
+            mean_data = 0.0f;
             numerator = 0.0f;
 
             // load template and data into shared memory
@@ -92,10 +93,19 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
             // calculate correlation coefficient
             if (last_sample_trace <= n_samples_data){
                 // if not, corresponds to an ill-defined CC with some samples out of the bounds
+                // Calculate the mean if fully normalising
+                if (normalize > 0){
+                    for (i = 0; i < n_samples_template; i++){
+                        mean_data += data_s[i + threadIdx.x * step];
+                    }
+                    mean_data /= n_samples_template;
+                }
+
                 for(i = 0; i < n_samples_template; i++) {
-                    data_sample = data_s[i + threadIdx.x * step];
+                    data_sample = data_s[i + threadIdx.x * step] - mean_data;
                     numerator += data_sample * templates_s[i];
-                    sum_square_data += data_sample * data_sample; 
+                    sum_square_data += data_sample * data_sample;
+                    
                 }
                 //denominator = sum_square_data * sum_square_template[sum_square_template_offset];
                 denominator = sum_square_data * ss_template[0];
@@ -131,7 +141,7 @@ void matched_filter(float *templates, float *sum_square_templates,
                     int *moveouts, float *data, float *weights, size_t step,
                     size_t n_samples_template, size_t n_samples_data,
                     size_t n_templates, size_t n_stations, size_t n_components, size_t n_corr,
-                    float *cc_sums) {
+                    float *cc_sums, int normalize) {
 
     int t_global = -1;
     int nGPUs;
@@ -281,7 +291,8 @@ void matched_filter(float *templates, float *sum_square_templates,
                                                     n_components,
                                                     chunk_offset,
                                                     cs,
-                                                    cc_mat_d);
+                                                    cc_mat_d,
+                                                    normalize);
 
                 // return an error if something happened in the kernel (and crash the program)
                 gpuErrchk(cudaPeekAtLastError());

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -111,7 +111,9 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
                 denominator = sum_square_data * ss_template[0];
                 if (cc_mat_offset < (chunk_size * n_stations * n_components)){
                     // check that this thread is not ouf of the chunk's bounds
-                    if (denominator > STABILITY_THRESHOLD) cc_mat[cc_mat_offset] = numerator * rsqrtf(denominator);
+                    if (denominator > STABILITY_THRESHOLD) {
+                        cc_mat[cc_mat_offset] = numerator * rsqrtf(denominator);
+                    }
                 }
             }
         }
@@ -132,7 +134,9 @@ __global__ void sum_cc(float *cc_mat, float *cc_sum, float *weights,
         float *cc_mat_offset;
 
         cc_mat_offset = cc_mat + i * n_stations * n_components;
-        for (ch = 0; ch < (n_stations * n_components); ch++) cc_sum[i] += cc_mat_offset[ch] * weights[ch];
+        for (ch = 0; ch < (n_stations * n_components); ch++){
+            cc_sum[i] += cc_mat_offset[ch] * weights[ch];
+        }
     }
 }
 
@@ -252,7 +256,8 @@ void matched_filter(float *templates, float *sum_square_templates,
             for (int i = 0; i < (n_stations * n_components); i++) {
                 max_moveout = (moveouts_t[i] > max_moveout) ? moveouts_t[i] : max_moveout;
             }
-            n_corr_t = (n_samples_data - n_samples_template - max_moveout) / step + 1;
+            // n_corr_t = (n_samples_data - n_samples_template - max_moveout) / step + 1;
+            n_corr_t = (n_samples_data - n_samples_template) / step + 1;
 
             // local pointers on the device
             templates_d_t = templates_d + t_thread * n_samples_template * n_stations * n_components;

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -90,7 +90,7 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
             __syncthreads(); // make sure the waveforms are read before keep going
 
             // calculate correlation coefficient
-            if (last_sample_trace < n_samples_data){
+            if (last_sample_trace <= n_samples_data){
                 // if not, corresponds to an ill-defined CC with some samples out of the bounds
                 for(i = 0; i < n_samples_template; i++) {
                     data_sample = data_s[i + threadIdx.x * step];

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -270,15 +270,11 @@ void matched_filter(float *templates, float *sum_square_templates,
                 // make sure the chunk is not going out of bounds
                 if (chunk_offset + chunk_size > n_corr_t){
                     cs = n_corr_t - chunk_offset;
+                    if (cs <= 0) continue;
                 }
                 else{
                     cs = chunk_size;
                 }
-                if (cs <= 0){
-                    // Reached end of valid correlation space.
-                    continue;
-                }
-                printf("cs: %i\n", cs);
                 //sizeof_cc_mat = sizeof(float) * cs * n_stations * n_components;
                 size_t sizeof_cc_sum_chunk = sizeof(float) * cs;
 

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -3,6 +3,6 @@ float network_corr(float*, float*, int*, float*, double*, float*, int, int, int,
 float corrc(float*, float, float*, double*, int);
 void cumsum_square_data(float*, int, float*, int, int, double*);
 void neumaier_cumsum_squared(float*, int, double*);
-void matched_filter_precise(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
-float network_corr_precise(float*, float*, int*, float*, float*, int, int, int, int, int);
-float corrc_precise(float*, float, float*, int);
+void matched_filter_precise(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*, int);
+float network_corr_precise(float*, float*, int*, float*, float*, int, int, int, int, int, int);
+float corrc_precise(float*, float, float*, int, int);

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -1,8 +1,8 @@
 void matched_filter(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
-float network_corr(float*, float*, int*, float*, double*, float*, int, int, int, int, int);
+float network_corr(float*, float*, int*, float*, double*, float*, int, int, int, int);
 float corrc(float*, float, float*, double*, int);
 void cumsum_square_data(float*, int, float*, int, int, double*);
 void neumaier_cumsum_squared(float*, int, double*);
 void matched_filter_precise(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*, int);
-float network_corr_precise(float*, float*, int*, float*, float*, int, int, int, int, int, int);
+float network_corr_precise(float*, float*, int*, float*, float*, int, int, int, int, int);
 float corrc_precise(float*, float, float*, int, int);

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -1,8 +1,8 @@
 void matched_filter(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
-float network_corr(float*, float*, int*, float*, double*, float*, int, int, int, int);
+float network_corr(float*, float*, int*, float*, double*, float*, int, int, int, int, int);
 float corrc(float*, float, float*, double*, int);
 void cumsum_square_data(float*, int, float*, int, int, double*);
 void neumaier_cumsum_squared(float*, int, double*);
 void matched_filter_precise(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
-float network_corr_precise(float*, float*, int*, float*, float*, int, int, int, int);
+float network_corr_precise(float*, float*, int*, float*, float*, int, int, int, int, int);
 float corrc_precise(float*, float, float*, int);

--- a/fast_matched_filter/src/matched_filter_GPU.h
+++ b/fast_matched_filter/src/matched_filter_GPU.h
@@ -1,1 +1,1 @@
-void matched_filter(float*, float*, int*, float*, float*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, float*);
+void matched_filter(float*, float*, int*, float*, float*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, float*, int);


### PR DESCRIPTION
Correlations for the last sample were systematically missed. This PR:
1. Increases the step end point for `arch = "precise"`,
2. Corrects the position used for accessing the appropriate `csum_square_data` for `arch = "cpu"`
3. Gets to the end of `n_samples_data` for `arch = "gpu"`
4. Implements a full normalization option.

I found these when working on getting my EQcorrscan FMF wrapper working fully - it might be worth having a test in the test-set that compares against a *really* naive implementation of correlation to ensure that the correlations are actually correct, not just that they compare favorably with each other?

I haven't done anything about matlab implementations.

---

Now included:
> p.s. Because I'm trying to get FMF working well within EQcorrscan (because it is so much faster than EQcorrscan correlations in most cases) you may see an additional PR that implements an option for full normalisation. I tried running FMF for my Kaikoura matching and ended up with a significantly lower MAD, and hence many more false detections than when using a fully normalised correlation.