### PR TITLE
Eric: Update to 1.4.1 with more flexibility on array size

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,12 +32,12 @@ LDFLAGS_GPU=--shared
 # CPU FLAGS
 COPTIMFLAGS_CPU=-O3
 # -march=native can cause problems on some CPUs; remove if needed
-CFLAGS_CPU=-fopenmp -fPIC -ftree-vectorize -march=native
+CFLAGS_CPU=-fopenmp -fPIC -ftree-vectorize -march=native -std=gnu99
 LDFLAGS_CPU=-shared
 
 # MEX FLAGS
 COPTIMFLAGS_MEX=-O3
-CFLAGS_MEX=-fopenmp -fPIC -march=native
+CFLAGS_MEX=-fopenmp -fPIC -march=native -std=gnu99
  # who knows why mex needs fopenmp again
 LDFLAGS_MEX=-fopenmp -shared
 

--- a/fast_matched_filter/__init__.py
+++ b/fast_matched_filter/__init__.py
@@ -15,4 +15,4 @@ del fast_matched_filter
 
 __all__ = [matched_filter, test_matched_filter]
 
-__version__ = '1.4.0'
+__version__ = '1.4.1'

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -10,7 +10,6 @@ Python bindings for the fast_matched_filter C libraries
 
 import numpy as np
 import ctypes as ct
-import datetime as dt
 import os
 
 path = os.path.join(os.path.dirname(__file__), 'lib')
@@ -228,7 +227,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu',
             n_corr,
             cc_sums.ctypes.data_as(ct.POINTER(ct.c_float)))
 
-    if arch == 'precise':
+    elif arch == 'precise':
         _libCPU.matched_filter_precise(
             templates.ctypes.data_as(ct.POINTER(ct.c_float)),
             sum_square_templates.ctypes.data_as(ct.POINTER(ct.c_float)),
@@ -291,11 +290,12 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu',
 
 def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
                         template_duration=10, data_duration=86400,
-                        sampling_rate=100, step=1, arch='cpu', check_zeros='first'):
+                        sampling_rate=100, step=1, arch='cpu',
+                        check_zeros='first', normalize='short'):
     """
     output: templates, moveouts, data, step, cc_sum
     """
-
+    from time import time as give_time
     template_times = np.random.random_sample(n_templates) * (data_duration / 2)
     # if step is not 1, not very likely that random times will be found
     if step != 1:
@@ -353,20 +353,21 @@ def test_matched_filter(n_templates=1, n_stations=1, n_components=1,
 
     weights = np.ones((n_templates, n_stations, n_components)) / (n_stations * n_components)
 
-    start_time = dt.datetime.now()
+    start_time = give_time()
     cc_sum = matched_filter(templates,
                             moveouts,
                             weights,
                             data,
                             step,
                             arch=arch,
-                            check_zeros=check_zeros)
-    stop_time = dt.datetime.now()
+                            check_zeros=check_zeros,
+                            normalize=normalize)
+    stop_time = give_time()
 
     print("Matched filter ({}) for {} templates on {} stations/{} "
-          "components over {} samples ({} step) ran in {}s".
+            "components over {} samples ({} step) ran in {:.3f}s".
           format(arch, n_templates, n_stations, n_components, n_samples_data,
-                 step, (stop_time - start_time).total_seconds()))
+                 step, (stop_time - start_time)))
 
     return templates, moveouts, data, step, cc_sum
 

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -46,7 +46,8 @@ try:
         ct.c_size_t,               # n_stations
         ct.c_size_t,               # n_components
         ct.c_size_t,               # n_corr
-        ct.POINTER(ct.c_float)]    # cc_sums
+        ct.POINTER(ct.c_float),    # cc_sums
+        ct.c_int]                  # normalize
     CPU_LOADED = True
 
 except OSError:
@@ -69,7 +70,8 @@ try:
         ct.c_size_t,               # n_stations
         ct.c_size_t,               # n_components
         ct.c_size_t,               # n_corr
-        ct.POINTER(ct.c_float)]    # cc_sums
+        ct.POINTER(ct.c_float),    # cc_sums
+        ct.c_int]                  # normalize
     GPU_LOADED = True
 
 except OSError:
@@ -138,30 +140,30 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu',
     # figure out and check input formats
     impossible_dimensions = False
     if templates.ndim > data.ndim:
-        n_templates = np.int32(templates.shape[0])
+        n_templates = int(templates.shape[0])
 
         assert templates.shape[1] == data.shape[0] # check stations
-        n_stations = np.int32(templates.shape[1])
+        n_stations = int(templates.shape[1])
 
         if templates.ndim == 4:
             assert templates.shape[2] == data.shape[1] # check components
-            n_components = np.int32(templates.shape[2])
+            n_components = int(templates.shape[2])
         elif templates.ndim == 3:
-            n_components = np.int32(1)
+            n_components = int(1)
         else:
             impossible_dimensions = True
 
     elif templates.ndim == data.ndim:
-        n_templates = np.int32(1)
+        n_templates = int(1)
         
         assert templates.shape[0] == data.shape[0] # check stations
-        n_stations = np.int32(templates.shape[0])
+        n_stations = int(templates.shape[0])
 
         if templates.ndim == 3:
             assert templates.shape[1] == data.shape[1] # check components
-            n_components = np.int32(templates.shape[1])
+            n_components = int(templates.shape[1])
         elif templates.ndim == 2:
-            n_components = np.int32(1)
+            n_components = int(1)
         else:
             impossible_dimensions = True
 
@@ -194,7 +196,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu',
         elif (n_templates * n_stations * n_components) / weights.size == 1.:
             weights = weights.reshape(n_templates, n_stations, n_components)
 
-    n_corr = np.int32((n_samples_data - n_samples_template) / step + 1)
+    n_corr = int((n_samples_data - n_samples_template) / step + 1)
 
     # compute sum of squares for templates
     sum_square_templates = np.sum(templates**2, axis=-1).astype(np.float32)
@@ -204,7 +206,7 @@ def matched_filter(templates, moveouts, weights, data, step, arch='cpu',
 
     moveouts = np.int32(moveouts.flatten())
     weights = np.float32(weights.flatten())
-    step = np.int32(step)
+    step = int(step)
     # Note: shouldn't need to enforce int here because they were np.int32 before
 
     data = np.float32(data.flatten())

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -22,6 +22,10 @@ void matched_filter(float *templates, float *sum_square_templates, int *moveouts
                     size_t n_samples_data, size_t n_templates, size_t n_stations,
                     size_t n_components, size_t n_corr, float *cc_sum) { // output variable
 
+    /* Optimized computation (Neumaier algorithm) of the sum of the squared
+     * data samples. Fast but sometimes inaccurate when large amplitudes are
+     * recorded (e.g. large and proximal earthquakes). */
+
     size_t start_i, stop_i, cc_i;
     int min_moveout, max_moveout;
     size_t network_offset, station_offset, cc_sum_offset;
@@ -182,6 +186,12 @@ void matched_filter_precise(float *templates, float *sum_square_templates, int *
                             float *data, float *weights, size_t step, size_t n_samples_template,
                             size_t n_samples_data, size_t n_templates, size_t n_stations,
                             size_t n_components, size_t n_corr, float *cc_sum, int normalize) { // output variable
+
+     /* Simple but slower computation of The sum of the squared data samples.
+     *  Give higher precision results, in particular when large amplitudes
+     *  are present in the data. This function is called when arch='precise' 
+     *  is given to the wrapper. It supports both the short and the full 
+     *  normalization. */
 
     size_t t, ch;
     size_t start_i, stop_i, cc_i;

--- a/fast_matched_filter/src/matched_filter.cu
+++ b/fast_matched_filter/src/matched_filter.cu
@@ -32,22 +32,23 @@ inline void gpuAssert(cudaError_t code, const char *file, int line, bool abort=t
 }
 
 //-------------------------------------------------------------------------
-__global__ void network_corr(float *templates, float *sum_square_template, int *moveout, float *data, float *weights,
+__global__ void network_corr(float *templates, float *sum_square_template,
+                             int *moveout, float *data, float *weights,
                              size_t step, size_t n_samples_template, size_t n_samples_data,
                              size_t n_stations, size_t n_components,
-                             int chunk_offset, int chunk_size,
+                             size_t chunk_offset, size_t chunk_size,
                              float *cc_mat, int normalize) {
   
     // each thread matches the template to one time in the data
-    int idx, first_sample_block, first_sample_trace, last_sample_trace; // sample's index
-    int i, s, c; // counters
-    int data_offset, templates_offset, sum_square_template_offset, cc_mat_offset;
+    size_t idx, first_sample_block, first_sample_trace, last_sample_trace; // sample's index
+    size_t s; // counters
+    size_t data_offset, templates_offset, sum_square_template_offset, cc_mat_offset;
     float numerator, denominator, sum_square_data, mean_data;
     float data_sample;
-    int t_idx;
+    size_t t_idx;
 
     //------------------------------------------------
-    int count_template = (n_samples_template / WARPSIZE + 1) * WARPSIZE;
+    size_t count_template = (n_samples_template / WARPSIZE + 1) * WARPSIZE;
     extern __shared__ float shared[];
     float *ss_template = &shared[0];
     float *templates_s = &shared[sizeof(float)];
@@ -58,7 +59,7 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
     first_sample_block = idx * step;
     s = blockIdx.x % n_stations;
 
-    for (c = 0; c < n_components; c++){
+    for (size_t c = 0; c < n_components; c++){
         if (weights[s * n_components + c] != 0.){
             // compute offsets for input variables
             cc_mat_offset = (first_sample_block / step + threadIdx.x - chunk_offset) * n_stations * n_components + s * n_components + c;
@@ -101,7 +102,7 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
                     mean_data /= n_samples_template;
                 }
 
-                for(i = 0; i < n_samples_template; i++) {
+                for(size_t i = 0; i < n_samples_template; i++) {
                     data_sample = data_s[i + threadIdx.x * step] - mean_data;
                     numerator += data_sample * templates_s[i];
                     sum_square_data += data_sample * data_sample;
@@ -123,9 +124,10 @@ __global__ void network_corr(float *templates, float *sum_square_template, int *
 
 //-------------------------------------------------------------------------
 __global__ void sum_cc(float *cc_mat, float *cc_sum, float *weights,
-        int n_stations, int n_components, int n_corr, int chunk_offset, int chunk_size) {
+                       size_t n_stations, size_t n_components, size_t n_corr,
+                       size_t chunk_offset, size_t chunk_size) {
 
-    int i, ch;
+    size_t i;
 
     i = blockIdx.x * blockDim.x + threadIdx.x;
     if ( ((i + chunk_offset) < n_corr) & (i < chunk_size) ){
@@ -134,7 +136,7 @@ __global__ void sum_cc(float *cc_mat, float *cc_sum, float *weights,
         float *cc_mat_offset;
 
         cc_mat_offset = cc_mat + i * n_stations * n_components;
-        for (ch = 0; ch < (n_stations * n_components); ch++){
+        for (size_t ch = 0; ch < (n_stations * n_components); ch++){
             cc_sum[i] += cc_mat_offset[ch] * weights[ch];
         }
     }
@@ -144,7 +146,8 @@ __global__ void sum_cc(float *cc_mat, float *cc_sum, float *weights,
 void matched_filter(float *templates, float *sum_square_templates, 
                     int *moveouts, float *data, float *weights, size_t step,
                     size_t n_samples_template, size_t n_samples_data,
-                    size_t n_templates, size_t n_stations, size_t n_components, size_t n_corr,
+                    size_t n_templates, size_t n_stations,
+                    size_t n_components, size_t n_corr,
                     float *cc_sums, int normalize) {
 
     int t_global = -1;
@@ -154,7 +157,7 @@ void matched_filter(float *templates, float *sum_square_templates,
     cudaGetDeviceCount(&nGPUs);
     omp_set_num_threads(min(nGPUs, (int)n_templates));
 
-    int chunk_size = n_corr/NCHUNKS + 1;
+    size_t chunk_size = n_corr/NCHUNKS + 1;
 
     // Size of variables to create on the device (GPU)
     size_t sizeof_templates = sizeof(float) * n_samples_template * n_stations * n_components * n_templates;
@@ -192,7 +195,8 @@ void matched_filter(float *templates, float *sum_square_templates,
         size_t totalMem = 0;
         cudaMemGetInfo(&freeMem, &totalMem);
         if (sizeof_total > freeMem) {
-            printf("%zu bytes are requested on GPU #%i whereas it has only %zu free bytes.\n", sizeof_total, id, freeMem);
+            printf("%zu bytes are requested on GPU #%i whereas it has only %zu free bytes.\n",
+                   sizeof_total, id, freeMem);
             printf("Reduce the number of templates processed in one batch.\n");
             exit(0);
         }
@@ -234,17 +238,17 @@ void matched_filter(float *templates, float *sum_square_templates,
             if (t_thread >= (int)n_templates) break;
 
             // calculate the space required in the shared memory
-            int count_template = (n_samples_template / WARPSIZE + 1) * WARPSIZE;
-            int count_data = ((n_samples_template + BLOCKSIZE * step) / WARPSIZE + 1) * WARPSIZE;
-            int sharedMem = (count_template + count_data + 1) * sizeof(float);
+            size_t count_template = (n_samples_template / WARPSIZE + 1) * WARPSIZE;
+            size_t count_data = ((n_samples_template + BLOCKSIZE * step) / WARPSIZE + 1) * WARPSIZE;
+            size_t sharedMem = (count_template + count_data + 1) * sizeof(float);
             if (sharedMem > maxSharedMem) {
-                int new_step = (maxSharedMem/sizeof(float) - 2 * n_samples_template - 2 * WARPSIZE) / BLOCKSIZE;
-                int new_length = maxSharedMem/sizeof(float) - count_data - WARPSIZE;
+                size_t new_step = (maxSharedMem/sizeof(float) - 2 * n_samples_template - 2 * WARPSIZE) / BLOCKSIZE;
+                size_t new_length = maxSharedMem/sizeof(float) - count_data - WARPSIZE;
                 if (new_length < 0) new_length = 0;
-                printf("The maximum shared memory available on this card is %i bytes "\
-                        "(%i bytes required). You should consider the different options:\n"\
-                        "  - Change the temporal step to %i without changing the template length.\n"\
-                        "  - Change the template length to %i without changing the temporal step.\n"\
+                printf("The maximum shared memory available on this card is %zu bytes "\
+                        "(%zu bytes required). You should consider the different options:\n"\
+                        "  - Change the temporal step to %zu without changing the template length.\n"\
+                        "  - Change the template length to %zu without changing the temporal step.\n"\
                         "  - Try to decrease both of these parameters.\n",
                         maxSharedMem, sharedMem, new_step, new_length);
                 exit(0);
@@ -253,7 +257,7 @@ void matched_filter(float *templates, float *sum_square_templates,
             // compute the number of correlation steps for this template
             moveouts_t = moveouts + t_thread * n_stations * n_components;
             max_moveout = 0;
-            for (int i = 0; i < (n_stations * n_components); i++) {
+            for (size_t i = 0; i < (n_stations * n_components); i++) {
                 max_moveout = (moveouts_t[i] > max_moveout) ? moveouts_t[i] : max_moveout;
             }
             n_corr_t = (n_samples_data - n_samples_template - max_moveout) / step + 1;
@@ -264,9 +268,9 @@ void matched_filter(float *templates, float *sum_square_templates,
             moveouts_d_t = moveouts_d + t_thread * n_stations * n_components;
             weights_d_t = weights_d + t_thread * n_stations * n_components;
             
-            for (int ch = 0; ch < NCHUNKS; ch++){
-                int chunk_offset = ch * chunk_size;
-                int cs;
+            for (size_t ch = 0; ch < NCHUNKS; ch++){
+                size_t chunk_offset = ch * chunk_size;
+                size_t cs;
                 // make sure the chunk is not going out of bounds
                 if (chunk_offset + chunk_size > n_corr_t){
                     cs = n_corr_t - chunk_offset;

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -1,8 +1,13 @@
-void matched_filter(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*);
-float network_corr(float*, float*, int*, float*, double*, float*, int, int, int, int);
-float corrc(float*, float, float*, double*, int);
-void cumsum_square_data(float*, int, float*, int, int, double*);
-void neumaier_cumsum_squared(float*, int, double*);
-void matched_filter_precise(float*, float*, int*, float*, float*, int, int, int, int, int, int, int, float*, int);
-float network_corr_precise(float*, float*, int*, float*, float*, int, int, int, int, int);
-float corrc_precise(float*, float, float*, int, int);
+void matched_filter(float*, float*, int*, float*, float*,
+                    size_t, size_t, size_t, size_t, size_t, size_t, size_t, float*);
+float network_corr(float*, float*, int*, float*, double*,
+                   float*, size_t, size_t, size_t, size_t);
+float corrc(float*, float, float*, double*, size_t);
+void cumsum_square_data(float*, size_t, float*, size_t, size_t, double*);
+void neumaier_cumsum_squared(float*, size_t, double*);
+void matched_filter_precise(float*, float*, int*, float*, float*,
+                            size_t, size_t, size_t, size_t, size_t,
+                            size_t, size_t, float*, int);
+float network_corr_precise(float*, float*, int*, float*, float*,
+                           size_t, size_t, size_t, size_t, int);
+float corrc_precise(float*, float, float*, size_t, int);

--- a/fast_matched_filter/src/matched_filter_GPU.h
+++ b/fast_matched_filter/src/matched_filter_GPU.h
@@ -1,1 +1,4 @@
-void matched_filter(float*, float*, int*, float*, float*, size_t, size_t, size_t, size_t, size_t, size_t, size_t, float*, int);
+void matched_filter(
+        float*, float*, int*, float*, float*,
+        size_t, size_t, size_t, size_t, size_t,
+        size_t, size_t, float*, int);

--- a/setup.py
+++ b/setup.py
@@ -47,14 +47,14 @@ with open('README.md') as f:
     long_description = f.read()
 
 setup(name='FastMatchedFilter',
-      version='1.4.0',
+      version='1.4.1',
       description='Fast time-domain normalised cross-correlation for '
                   'CPU & GPU',
       long_description=long_description,
       classifiers=[
         'Development Status :: 3 - Alpha',
         'License :: GPL License',
-        'Programming Language :: Python :: 2.7, 3.5, 3.6, 3.7, 3.8',
+        'Programming Language :: Python :: 2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10',
         'Topic :: Seismology :: Matched Filter',
       ],
       url='https://github.com/beridel/fast_matched_filter',


### PR DESCRIPTION
In this update from 1.4.0 to 1.4.1, I changed all the integer numbers that described array sizes to integer types that support bigger numbers. For example, the (n_templates * n_corr) in the python wrapper was unnecessarily cast to int32 and it easily resulted in overflows. In the C and CUDA/C code, I changed int to size_t wherever was adequate. Note that the elements of the arrays that were int32 are still int32, just the size variables changed. 

This now allows a much better use of the new GPUs that typically fit large arrays in their memory.

I took the liberty to re-write the doc strings so that it can be used to generate an api documentation with Sphinx. You can check out the new documentation at: [https://ebeauce.github.io/FMF_documentation/index.html](https://ebeauce.github.io/FMF_documentation/index.html)  (same link as before). 