### PR TITLE
Variable template length (Frank and Abercrombie, 2018)

### DIFF
--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -38,7 +38,7 @@ try:
     _libCPU.matched_filter_precise.argtypes = argtypes + [ct.c_int]  # normalize
     _libCPU.matched_filter_no_sum.argtypes = argtypes
     _libCPU.matched_filter_precise_no_sum.argtypes = argtypes + [ct.c_int]
-    _libCPU.matched_filter_variable_precise.argtypes = argtypes[0:6] + [ct.POINTER(ct.c_int)] + argtypes[7:]
+    _libCPU.matched_filter_variable_precise.argtypes = argtypes[0:6] + [ct.POINTER(ct.c_int)] + argtypes[7:] + [ct.c_int]
     CPU_LOADED = True
 
 except OSError:

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -203,6 +203,7 @@ def matched_filter(
         max_samples_template = n_samples_template
         variable_template_length = False
     else:
+        assert n_samples_template.shape == moveouts.shape
         variable_template_length = True
         max_samples_template = np.max(n_samples_template)
         n_samples_template = np.ascontiguousarray(n_samples_template.flatten(), dtype=np.int32)
@@ -274,7 +275,6 @@ def matched_filter(
         cc.ctypes.data_as(ct.POINTER(ct.c_float)),
     )
     if variable_template_length:
-        assert n_samples_template.shape == moveouts.shape
         args_list = list(args)
         args_list[6] = n_samples_template.ctypes.data_as(ct.POINTER(ct.c_int))   
         args = tuple(args_list)

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -258,24 +258,26 @@ def matched_filter(
         )
 
     # list of arguments
-     args = [
-            templates.ctypes.data_as(ct.POINTER(ct.c_float)),
-            sum_square_templates.ctypes.data_as(ct.POINTER(ct.c_float)),
-            moveouts.ctypes.data_as(ct.POINTER(ct.c_int)),
-            data.ctypes.data_as(ct.POINTER(ct.c_float)),
-            weights.ctypes.data_as(ct.POINTER(ct.c_float)),
-            step,
-            n_samples_template,
-            n_samples_data,
-            n_templates,
-            n_stations,
-            n_components,
-            n_corr,
-            cc.ctypes.data_as(ct.POINTER(ct.c_float)),
-        ]
+    args = (
+        templates.ctypes.data_as(ct.POINTER(ct.c_float)),
+        sum_square_templates.ctypes.data_as(ct.POINTER(ct.c_float)),
+        moveouts.ctypes.data_as(ct.POINTER(ct.c_int)),
+        data.ctypes.data_as(ct.POINTER(ct.c_float)),
+        weights.ctypes.data_as(ct.POINTER(ct.c_float)),
+        step,
+        n_samples_template,
+        n_samples_data,
+        n_templates,
+        n_stations,
+        n_components,
+        n_corr,
+        cc.ctypes.data_as(ct.POINTER(ct.c_float)),
+    )
     if variable_template_length:
         assert n_samples_template.shape == moveouts.shape
-        args[6] = n_samples_template.ctypes.data_as(ct.POINTER(ct.c_int))   
+        args_list = list(args)
+        args_list[6] = n_samples_template.ctypes.data_as(ct.POINTER(ct.c_int))   
+        args = tuple(args_list)
 
     if arch == "cpu" and network_sum:
         _libCPU.matched_filter(*args)

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -335,16 +335,11 @@ void matched_filter_variable_precise(
 
     
     /* find longest template */
-    for (size_t t = 0; t < n_templates; t++)
+    for (size_t tr = 0; tr < (n_templates * n_stations * n_components); tr++)
     {
-        network_offset = t * n_stations * n_components;
-
-        for (size_t ch = 0; ch < (n_stations * n_components); ch++)
+        if (n_samples_template[tr] > max_samples_template)
         {
-            if (n_samples_template[network_offset + ch] > max_samples_template)
-            {
-                max_samples_template = n_samples_template[network_offset + ch];
-            }
+            max_samples_template = n_samples_template[tr];
         }
     }
 
@@ -402,7 +397,7 @@ void matched_filter_variable_precise(
 
 #pragma omp parallel for 
         for (size_t i = 0; i < n_corr; i++) {
-            cc_sum[cc_sum_offset + i] = tanhf(cc_sum[cc_sum_offset + i] / cc_norm_sum) + n_stations * n_components * FLT_EPSILON;
+            cc_sum[cc_sum_offset + i] = tanhf(cc_sum[cc_sum_offset + i] / cc_norm_sum) + n_stations * n_components * FLT_EPSILON * 10;
         }
     }
 
@@ -596,7 +591,7 @@ float network_corr_variable_precise(
                                data + d,
                                n_samples_template[component_offset],
                                normalize);
-            cc_sum += atanhf(cc - FLT_EPSILON) * cc_norm[component_offset];
+            cc_sum += atanhf(cc - 10 * FLT_EPSILON) * cc_norm[component_offset];
         }
     }
     

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -402,7 +402,7 @@ void matched_filter_variable_precise(
 
 #pragma omp parallel for 
         for (size_t i = 0; i < n_corr; i++) {
-            cc_sum[cc_sum_offset + i] = tanhf(cc_sum[cc_sum_offset + i] / cc_norm_sum) + FLT_EPSILON;
+            cc_sum[cc_sum_offset + i] = tanhf(cc_sum[cc_sum_offset + i] / cc_norm_sum) + n_stations * n_components * FLT_EPSILON;
         }
     }
 

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -318,6 +318,96 @@ void matched_filter_precise_no_sum(
     }
 }
 
+void matched_filter_variable_precise(
+    float *templates, float *sum_square_templates, int *moveouts,
+    float *data, float *weights, size_t step,
+    int *n_samples_template, size_t n_samples_data, size_t n_templates, size_t n_stations,
+    size_t n_components, size_t n_corr, float *cc_sum, int normalize)
+{
+    size_t start_i, stop_i, cc_i;
+    int max_samples_template = 0, min_moveout, max_moveout;
+    size_t network_offset, station_offset, cc_sum_offset;
+    int *moveouts_t = NULL, *n_samples_template_t = NULL;
+    float *templates_t = NULL, *sum_square_templates_t = NULL, *weights_t = NULL;
+    float *cc_norm = NULL, cc_norm_sum;
+
+    cc_norm = malloc(n_stations * n_components * sizeof(float));
+
+    
+    /* find longest template */
+    for (size_t t = 0; t < n_templates; t++)
+    {
+        network_offset = t * n_stations * n_components;
+
+        for (size_t ch = 0; ch < (n_stations * n_components); ch++)
+        {
+            if (n_samples_template[network_offset + ch] > max_samples_template)
+            {
+                max_samples_template = n_samples_template[network_offset + ch];
+            }
+        }
+    }
+
+    /* run matched filter template by template */
+    for (size_t t = 0; t < n_templates; t++) {
+        network_offset = t * n_stations * n_components;
+        station_offset = t * n_stations;
+        cc_sum_offset = t * n_corr;
+
+        // find min/max moveout and template vector position
+        min_moveout = 0;
+        max_moveout = 0;
+        for (size_t ch = 0; ch < (n_stations * n_components); ch++)
+        {
+            if (moveouts[network_offset + ch] < min_moveout)
+                min_moveout = moveouts[network_offset + ch];
+            if (moveouts[network_offset + ch] > max_moveout)
+                max_moveout = moveouts[network_offset + ch];
+        }
+    
+        templates_t = templates + network_offset * max_samples_template;
+        moveouts_t = moveouts + network_offset;
+        weights_t = weights + network_offset;
+        sum_square_templates_t = sum_square_templates + network_offset;
+        n_samples_template_t = n_samples_template + network_offset;
+
+        /* calculate CC norm for each station based on number of samples per station */
+        cc_norm_sum = 0;
+        for (size_t ch = 0; ch < (n_stations * n_components); ch++)
+        {
+            cc_norm[ch] = 1. / sqrtf(1. / (n_samples_template[network_offset + ch] - 3)) * weights[network_offset + ch];
+            cc_norm_sum += cc_norm[ch];
+        }
+
+        start_i = (int)(ceilf(abs(min_moveout) / (float)step)) * step;
+        stop_i = n_samples_data - max_samples_template - max_moveout - step;
+
+#pragma omp parallel for private(cc_i)
+        for (size_t i = start_i; i < stop_i; i += step)
+        {
+            cc_i = i / step;
+            cc_sum[cc_sum_offset + cc_i] = network_corr_variable_precise(templates_t,
+                                                                         sum_square_templates_t,
+                                                                         moveouts_t,
+                                                                         data + i,
+                                                                         weights_t,
+                                                                         cc_norm,
+                                                                         n_samples_template_t,
+                                                                         max_samples_template,
+                                                                         n_samples_data,
+                                                                         n_stations,
+                                                                         n_components,
+                                                                         normalize);
+        }
+
+#pragma omp parallel for 
+        for (size_t i = 0; i < n_corr; i++) {
+            cc_sum[cc_sum_offset + i] = tanhf(cc_sum[cc_sum_offset + i] / cc_norm_sum) + FLT_EPSILON;
+        }
+    }
+
+    free(cc_norm);
+}
 //-------------------------------------------------------------------------
 //        computation of network correlation coefficients
 
@@ -368,7 +458,7 @@ float network_corr_precise(
     size_t n_stations, size_t n_components, int normalize)
 {
 
-    size_t d, dd, t;
+    size_t d, t;
     size_t station_offset, component_offset;
     float cc, cc_sum = 0; // output
 
@@ -388,12 +478,12 @@ float network_corr_precise(
 
             t = component_offset * n_samples_template;
             d = component_offset * n_samples_data + moveouts[component_offset];
-            dd = component_offset * (n_samples_data + 1) + moveouts[component_offset];
 
             cc = corrc_precise(templates + t,
                                sum_square_template[component_offset],
                                data + d,
-                               n_samples_template, normalize);
+                               n_samples_template,
+                               normalize);
             cc_sum += cc * weights[component_offset];
         }
     }
@@ -472,6 +562,45 @@ void network_corr_precise_no_sum(
                 n_samples_template, normalize);
         }
     }
+}
+
+float network_corr_variable_precise(
+    float *templates, float *sum_square_template, int *moveouts,
+    float *data, float *weights, float *cc_norm, int *n_samples_template, size_t max_samples_template,
+    size_t n_samples_data, size_t n_stations, size_t n_components, int normalize)
+{
+
+    size_t d, t;
+    size_t station_offset, component_offset;
+    float cc, cc_sum = 0; // output
+
+    for (size_t s = 0; s < n_stations; s++)
+    {
+
+        station_offset = s * n_components;
+
+        cc = 0;
+        for (size_t c = 0; c < n_components; c++)
+        {
+            component_offset = station_offset + c;
+            if (weights[component_offset] == 0)
+                continue;
+
+            // if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
+
+            t = component_offset * max_samples_template;
+            d = component_offset * n_samples_data + moveouts[component_offset];
+
+            cc = corrc_precise(templates + t,
+                               sum_square_template[component_offset],
+                               data + d,
+                               n_samples_template[component_offset],
+                               normalize);
+            cc_sum += atanhf(cc * weights[component_offset] - FLT_EPSILON) * cc_norm[component_offset];
+        }
+    }
+    
+    return cc_sum;
 }
 
 //-------------------------------------------------------------------------

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -596,7 +596,7 @@ float network_corr_variable_precise(
                                data + d,
                                n_samples_template[component_offset],
                                normalize);
-            cc_sum += atanhf(cc * weights[component_offset] - FLT_EPSILON) * cc_norm[component_offset];
+            cc_sum += atanhf(cc - FLT_EPSILON) * cc_norm[component_offset];
         }
     }
     

--- a/fast_matched_filter/src/matched_filter_CPU.h
+++ b/fast_matched_filter/src/matched_filter_CPU.h
@@ -52,6 +52,18 @@ float corrc_precise_no_sum(
         float*, float, float*, size_t, int
         );
 
+void matched_filter_variable_precise(
+    float*, float*, int*,
+    float*, float*, size_t,
+    int*, size_t, size_t, size_t,
+    size_t, size_t, float*, int);
+
+float network_corr_variable_precise(
+    float*, float*, int*,
+    float *, float*, float*, int*, size_t,
+    size_t, size_t, size_t, int);
+
+
 void cumsum_square_data(
         float*, size_t, float*, size_t, size_t, double*
         );


### PR DESCRIPTION
So I've finally gotten around to implementing the variable template length version of the matched-filter search (cf. Frank and Abercrombie, BSSA, 2018 for details).

I ran into some weird ctypes errors, so I ended up having to manually write up the argstypes list. Likely some python subtleties that escape me...

But the following works:
```import fast_matched_filter as fmf
import numpy as np
(templates, moveouts, data, step, cc_sum, run_time) = fmf.test_matched_filter(n_stations=3, arch='precise')
n_samples_template = np.ones(moveouts.shape) * templates.shape[-1]
n_samples_template[0, 2, 0] = 500
cc_sum = fmf.matched_filter(templates,
    moveouts,
    np.ones(moveouts.shape),
    data,
    step,
    n_samples_template=n_samples_template,
    arch='variable_precise')
```
    
Any thoughts on how to do this better? Anything that I'm potentially breaking that I'm not taking into account here?