### PR TITLE
Replace bitwise flip operator "~" with "not" (unexpected behavior with np.bool vs bool)

### DIFF
--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -292,7 +292,7 @@ def matched_filter(
     elif arch == "variable_precise" and network_sum:
         args = args + (normalize,)
         _libCPU.matched_filter_variable_precise(*args)
-    elif arch == "variable_precise" and ~network_sum:
+    elif arch == "variable_precise" and not network_sum:
         #args = args + (normalize,)
         #_libCPU.matched_filter_variable_precise_no_sum(*args)
         raise NotImplementedError("Variable precise without network sum is not yet implemented.")

--- a/fast_matched_filter/fast_matched_filter.py
+++ b/fast_matched_filter/fast_matched_filter.py
@@ -264,12 +264,12 @@ def matched_filter(
 
     if arch == "cpu" and network_sum:
         _libCPU.matched_filter(*args)
-    elif arch == "cpu" and ~network_sum:
+    elif arch == "cpu" and not network_sum:
         _libCPU.matched_filter_no_sum(*args)
     elif arch == "precise" and network_sum:
         args = args + (normalize,)
         _libCPU.matched_filter_precise(*args)
-    elif arch == "precise" and ~network_sum:
+    elif arch == "precise" and not network_sum:
         args = args + (normalize,)
         _libCPU.matched_filter_precise_no_sum(*args)
     elif arch == "gpu":
@@ -311,7 +311,7 @@ def matched_filter(
 
     if check_zeros:
         msg_threshold = 10
-        if ~network_sum:
+        if not network_sum:
             msg_threshold *= np.sum(weights[0, ...] > 0.0)
         for t in range(zeros.shape[0]):
             if zeros[t] > msg_threshold:


### PR DESCRIPTION
Thanks a lot for develop `fast_matched_filter`!
I noticed that I sometimes got some unexpected warning messages in a recent version on the `check_zeros:`-bit.

This was due to how the bitwise-flip operator "~" works with builtin vs. numpy-booleans in Python:
```python
~np.bool_(0) == True
~np.bool_(1) == False
~True == -2
~False == -1 
```
And `if ~True:` evaluates to `True`, so one can end up in the wrong part of an if / else statement. The save thing is replace "~" with "not" in this case.