### PR TITLE
Variable template length fixes

### DIFF
--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -432,7 +432,7 @@ float network_corr(
         for (size_t c = 0; c < n_components; c++)
         {
             component_offset = station_offset + c;
-            if (weights[component_offset] == 0)
+            if (weights[component_offset] == 0.)
                 continue;
 
             // if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
@@ -472,7 +472,7 @@ float network_corr_precise(
         for (size_t c = 0; c < n_components; c++)
         {
             component_offset = station_offset + c;
-            if (weights[component_offset] == 0)
+            if (weights[component_offset] == 0.)
                 continue;
 
             // if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
@@ -510,7 +510,7 @@ void network_corr_no_sum(
         for (size_t c = 0; c < n_components; c++)
         {
             component_offset = station_offset + c;
-            if (weights[component_offset] == 0)
+            if (weights[component_offset] == 0.)
                 continue;
 
             // if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
@@ -547,7 +547,7 @@ void network_corr_precise_no_sum(
         for (size_t c = 0; c < n_components; c++)
         {
             component_offset = station_offset + c;
-            if (weights[component_offset] == 0)
+            if (weights[component_offset] == 0.)
                 continue;
 
             // if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;
@@ -584,7 +584,7 @@ float network_corr_variable_precise(
         for (size_t c = 0; c < n_components; c++)
         {
             component_offset = station_offset + c;
-            if (weights[component_offset] == 0)
+            if (weights[component_offset] == 0.)
                 continue;
 
             // if ((i + moveouts[component_offset]) > n_samples_data - n_samples_template) continue;

--- a/fast_matched_filter/src/matched_filter.c
+++ b/fast_matched_filter/src/matched_filter.c
@@ -353,6 +353,7 @@ void matched_filter_variable_precise(
         // find min/max moveout and template vector position
         min_moveout = 0;
         max_moveout = 0;
+        n_traces_used = 0;
         for (size_t ch = 0; ch < (n_stations * n_components); ch++)
         {
             if (moveouts[network_offset + ch] < min_moveout)


### PR DESCRIPTION
Hello,

Just a few little changes here:
- updated `test_matched_filter` to allow for `arch='variable_precise'`
- removed normalization from the `test_matched_filter` cc output
- updated the variable length C code to not be normalized between -1 and 1 regardless the number of traces (stations x components) used

Let me know if you have any comments/suggestions.